### PR TITLE
bug fixing + shortenning

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ ysoserial.net generates deserialization payloads for a variety of .NET formatter
 		Formatters: BinaryFormatter (3) , DataContractSerializer (2) , Json.Net (2) , LosFormatter (3) , NetDataContractSerializer (3) , SoapFormatter (2)
 	(*) WindowsIdentity
 		Formatters: BinaryFormatter , DataContractSerializer , Json.Net , LosFormatter , NetDataContractSerializer , SoapFormatter
+	(*) WindowsPrincipal
+		Formatters: BinaryFormatter , DataContractJsonSerializer , DataContractSerializer , Json.Net , LosFormatter , NetDataContractSerializer , SoapFormatter
 
 == PLUGINS ==
 	(*) ActivatorUrl (Sends a generated payload to an activated, presumably remote, object)
@@ -233,7 +235,7 @@ Credits for available gadgets:
 	SessionViewStateHistoryItem
 		[Finders: Soroush Dalili]
 	TextFormattingRunProperties
-		[Finders: Oleksandr Mirosh and Alvaro Munoz] [Contributors: Alvaro Munoz, Soroush Dalili]
+		[Finders: Oleksandr Mirosh and Alvaro Munoz] [Contributors: Oleksandr Mirosh, Soroush Dalili]
 	TypeConfuseDelegate
 		[Finders: James Forshaw] [Contributors: Alvaro Munoz]
 	TypeConfuseDelegateMono
@@ -242,6 +244,8 @@ Credits for available gadgets:
 		[Finders: Soroush Dalili]
 	WindowsIdentity
 		[Finders: Levi Broderick] [Contributors: Alvaro Munoz, Soroush Dalili]
+	WindowsPrincipal
+		[Finders: Steven Seeley of Qihoo 360 Vulcan Team] [Contributors: Chris Anastasio]
 
 Credits for available plugins:
 	ActivatorUrl

--- a/ysoserial/Generators/GenericGenerator.cs
+++ b/ysoserial/Generators/GenericGenerator.cs
@@ -119,9 +119,6 @@ namespace ysoserial.Generators
 
         public object Serialize(object payloadObj, string formatter, InputArgs inputArgs)
         {
-            // Disable ActivitySurrogate type protections during generation
-            ConfigurationManager.AppSettings.Set("microsoft:WorkflowComponentModel:DisableActivitySurrogateSelectorTypeCheck", "true");
-
             MemoryStream stream = new MemoryStream();
           
             if (formatter.ToLower().Equals("binaryformatter"))

--- a/ysoserial/Helpers/SerializersHelper.cs
+++ b/ysoserial/Helpers/SerializersHelper.cs
@@ -142,11 +142,13 @@ namespace ysoserial.Helpers
 
         public static void TestAll(object myobj)
         {
-            TestAll(myobj, myobj.GetType());
+            TestAll(myobj, myobj.GetType(), null);
         }
 
-        public static void TestAll(object myobj, Type type)
+        public static void TestAll(object myobj, Type type, Type[] knownTypes)
         {
+            // knownTypes is used in DataContractJsonSerializer_test
+
             StringBuilder sb = new StringBuilder();
             sb.Append("Object returned from:");            
             if(XmlSerializer_test(myobj, type) != null)
@@ -193,6 +195,11 @@ namespace ysoserial.Helpers
             {
                 sb.AppendLine("JavaScriptSerializer_test");
             }
+            if (DataContractJsonSerializer_test(myobj, type, knownTypes) != null)
+            {
+                sb.AppendLine("DataContractJsonSerializer_test");
+            }
+            Console.WriteLine(sb);
         }
 
         public static object XmlSerializer_test(object myobj)
@@ -696,28 +703,6 @@ namespace ysoserial.Helpers
             }
         }
 
-        public static object DataContractJsonSerializer_deserialize(string str, string type, Type[] types)
-        {
-            DataContractJsonSerializer js = new DataContractJsonSerializer(Type.GetType(type), new DataContractJsonSerializerSettings()
-            {
-                KnownTypes = types
-            });
-            byte[] byteArray = Encoding.UTF8.GetBytes(str);
-            MemoryStream ms = new MemoryStream(byteArray);
-            return js.ReadObject(ms);
-        }
-
-        public static string DataContractJsonSerializer_serialize(object gadget, string type, Type[] types)
-        {
-            DataContractJsonSerializer js = new DataContractJsonSerializer(Type.GetType(type), new DataContractJsonSerializerSettings()
-            {
-                KnownTypes = types
-            });
-            MemoryStream ms = new MemoryStream();
-            js.WriteObject(ms, gadget);
-            return Encoding.Default.GetString(ms.ToArray());
-        }
-
         public static string YamlDotNet_serialize(object myobj)
         {
             var serializer = new SerializerBuilder().Build();
@@ -761,6 +746,48 @@ namespace ysoserial.Helpers
             JavaScriptSerializer jss = new JavaScriptSerializer(new SimpleTypeResolver());
             return jss.Deserialize<Object>(str);
         }
-        
+
+        public static object DataContractJsonSerializer_test(object gadget, string type, Type[] knownTypes)
+        {
+            return DataContractJsonSerializer_test(gadget, Type.GetType(type), knownTypes);
+        }
+
+        public static object DataContractJsonSerializer_test(object gadget, Type type, Type[] knownTypes)
+        {
+            return DataContractJsonSerializer_deserialize(DataContractJsonSerializer_serialize(gadget, type, knownTypes), type, knownTypes);
+        } 
+
+        public static object DataContractJsonSerializer_deserialize(string str, string type, Type[] knownTypes)
+        {
+            return DataContractJsonSerializer_deserialize(str, Type.GetType(type), knownTypes);
+        }
+
+        public static object DataContractJsonSerializer_deserialize(string str, Type type, Type[] knownTypes)
+        {
+            DataContractJsonSerializer js = new DataContractJsonSerializer(type, new DataContractJsonSerializerSettings()
+            {
+                KnownTypes = knownTypes
+            });
+            byte[] byteArray = Encoding.UTF8.GetBytes(str);
+            MemoryStream ms = new MemoryStream(byteArray);
+            return js.ReadObject(ms);
+        }
+
+        public static string DataContractJsonSerializer_serialize(object gadget, string type, Type[] knownTypes)
+        {
+            return DataContractJsonSerializer_serialize(gadget, Type.GetType(type), knownTypes);
+        }
+
+        public static string DataContractJsonSerializer_serialize(object gadget, Type type, Type[] knownTypes)
+        {
+            DataContractJsonSerializer js = new DataContractJsonSerializer(type, new DataContractJsonSerializerSettings()
+            {
+                KnownTypes = knownTypes
+            });
+            MemoryStream ms = new MemoryStream();
+            js.WriteObject(ms, gadget);
+            return Encoding.Default.GetString(ms.ToArray());
+        }
+
     }
 }

--- a/ysoserial/Helpers/XMLMinifier.cs
+++ b/ysoserial/Helpers/XMLMinifier.cs
@@ -346,7 +346,11 @@ namespace ysoserial.Helpers
 
    <xsl:for-each select=""namespace::*"">
      <xsl:variable name=""vPrefix"" select=""name()""/>
+<!--
+Not sure why this one did not work so I had to change $vtheElem/descendant::* to //*
+-->
 
+<!--
      <xsl:if test=
       ""$vtheElem/descendant::* [namespace-uri() = current()     and
                    substring-before(name(),':') = $vPrefix or
@@ -354,7 +358,15 @@ namespace ysoserial.Helpers
                    @*[contains(.,concat($vPrefix,':'))]
                   ]
       "">
-      <xsl:copy-of select="".""/>
+-->
+      <xsl:if test=
+      ""//* [namespace-uri() = current()     and
+                   substring-before(name(),':') = $vPrefix or
+                   @*[substring-before(name(),':') = $vPrefix] or
+                   @*[contains(.,concat($vPrefix,':'))]
+                  ]
+      "">
+      <xsl:copy-of select=""."" />
      </xsl:if>
    </xsl:for-each>
    <xsl:apply-templates select=""node()|@*""/>

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Generators\SessionViewStateHistoryItemGenerator.cs" />
     <Compile Include="Generators\RolePrincipalGenerator.cs" />
     <Compile Include="Generators\ClaimsIdentityGenerator.cs" />
+    <Compile Include="Generators\WindowsPrincipalGenerator.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\AdvancedBinaryFormatterParser.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\binarycommonclasses.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\binaryconverter.cs" />


### PR DESCRIPTION
Fixed minifying bug in XML causing issues for WindowsPrincipal gadget (hpefully won't introduce another issue as XMLMinifier.cs has been updated!)

WindowsPrincipal gadget has been shortened by using another gadget

ActivitySurrogateSelector has been shortened more by fixing its BinaryFormatter/LosFormatter section (we do not need to use another gadget internally)