### PR TITLE
Readme update + ActivitySurrogateSelectorFromFile fixed

### DIFF
--- a/ExploitClass/ExploitClass.csproj
+++ b/ExploitClass/ExploitClass.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\ysoserial\bin\Debug\</OutputPath>
+    <OutputPath>..\ysoserial\bin\Release\</OutputPath>
     <DefineConstants>
     </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -41,12 +41,10 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ExploitClass.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Compile>
+    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Properties\" />
+    <Compile Include="ExploitClass.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Credits for available gadgets:
 	DataSet
 		[Finders: James Forshaw] [Contributors: Soroush Dalili]
 	ObjectDataProvider
-		[Finders: Oleksandr Mirosh, Alvaro Munoz] [Contributors: Alvaro Munoz, Soroush Dalili]
+		[Finders: Oleksandr Mirosh, Alvaro Munoz] [Contributors: Alvaro Munoz, Soroush Dalili, Dane Evans]
 	PSObject
 		[Finders: Oleksandr Mirosh, Alvaro Munoz] [Contributors: Alvaro Munoz]
 	ResourceSet

--- a/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
+++ b/ysoserial/Generators/ActivitySurrogateSelectorGenerator.cs
@@ -35,7 +35,7 @@ namespace ysoserial.Generators
         protected byte[] assemblyBytes;
         protected int variant_number = 1;
         protected InputArgs inputArgs = new InputArgs();
-        public PayloadClass() : this(1, new InputArgs()) { }
+        public PayloadClass() { }
         public PayloadClass(int variant_number, InputArgs inputArgs)
         {
             this.variant_number = variant_number;


### PR DESCRIPTION
Credit section updated in Readme

ActivitySurrogateSelectorFromFile needed the E.dll file to work which was missing from the Release version (wrong config fixed) so ActivitySurrogateSelectorGenerator.cs has been updated to make ActivitySurrogateSelectorFromFile  works as usual even with a missing E.dll