### PR TITLE
Typo fix: "poayloads" to "payloads"

### DIFF
--- a/ysoserial/Plugins/SharePointPlugin.cs
+++ b/ysoserial/Plugins/SharePointPlugin.cs
@@ -43,7 +43,7 @@ namespace ysoserial.Plugins
 
         public string Description()
         {
-            return "Generates poayloads for the following SharePoint CVEs: CVE-2020-1147, CVE-2019-0604, CVE-2018-8421";
+            return "Generates payloads for the following SharePoint CVEs: CVE-2020-1147, CVE-2019-0604, CVE-2018-8421";
         }
 
         public string Credit()


### PR DESCRIPTION
Just a quick, one-character typo fix.