### PR TITLE
Add IsolateApps supports

### DIFF
--- a/ExploitClass/ExploitClass.csproj
+++ b/ExploitClass/ExploitClass.csproj
@@ -35,6 +35,42 @@
     <StartupObject>
     </StartupObject>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <Optimize>true</Optimize>
+    <WarningLevel>0</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <Optimize>true</Optimize>
+    <WarningLevel>0</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
+    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Web" />

--- a/TestConsoleApp/TestConsoleApp_YSONET.csproj
+++ b/TestConsoleApp/TestConsoleApp_YSONET.csproj
@@ -33,6 +33,42 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/ysoserial.sln
+++ b/ysoserial.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1340
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ysoserial", "ysoserial\ysoserial.csproj", "{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}"
 EndProject
@@ -12,21 +12,49 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Debug|x64.ActiveCfg = Debug|x64
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Debug|x64.Build.0 = Debug|x64
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Debug|x86.ActiveCfg = Debug|x86
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Debug|x86.Build.0 = Debug|x86
 		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Release|x64.ActiveCfg = Release|x64
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Release|x64.Build.0 = Release|x64
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Release|x86.ActiveCfg = Release|x86
+		{6B40FDE7-14EA-4F57-8B7B-CC2EB4A25E6C}.Release|x86.Build.0 = Release|x86
 		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Debug|x64.ActiveCfg = Debug|x64
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Debug|x64.Build.0 = Debug|x64
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Debug|x86.ActiveCfg = Debug|x86
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Debug|x86.Build.0 = Debug|x86
 		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Release|x64.ActiveCfg = Release|x64
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Release|x64.Build.0 = Release|x64
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Release|x86.ActiveCfg = Release|x86
+		{0746F37A-9825-4E9D-A1EB-6DCC03B25C45}.Release|x86.Build.0 = Release|x86
 		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Debug|x64.ActiveCfg = Debug|x64
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Debug|x64.Build.0 = Debug|x64
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Debug|x86.ActiveCfg = Debug|x86
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Debug|x86.Build.0 = Debug|x86
 		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Release|x64.ActiveCfg = Release|x64
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Release|x64.Build.0 = Release|x64
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Release|x86.ActiveCfg = Release|x86
+		{E1E8C029-F7CD-4BD1-952E-E819B41520F0}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ysoserial/Plugins/ViewStatePlugin.cs
+++ b/ysoserial/Plugins/ViewStatePlugin.cs
@@ -246,8 +246,8 @@ namespace ysoserial.Plugins
 
                 if (isLegacy)
                 {
-
-                    dwCode = (int)StringComparer.InvariantCultureIgnoreCase.GetHashCode("/test233");
+                    // seems the result it's same as following code (without --legacy) but i don't know why :)
+                    dwCode = (int)StringComparer.InvariantCultureIgnoreCase.GetHashCode(IISAppInPathOrVirtualDir);
                 }
                 else
                 {

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -48,6 +48,46 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="fastjson, Version=2.1.0.0, Culture=neutral, PublicKeyToken=6b75a806b86095cd, processorArchitecture=MSIL">
       <HintPath>..\packages\fastJSON.2.1.27\lib\net40\fastjson.dll</HintPath>


### PR DESCRIPTION
Add IsolateApps support for generating viewstate payload.

Usage:
```bash
C:\Users\[REDACTED]\Desktop\Debug>ysoserial.exe -p ViewState -g TypeConfuseDelegate 
    -c calc
    --validationkey="220FFF8A54BB...,IsolateApps" --generator="C0C8685F" --isdebug 
    --apppath="/test233"
Calculated new ValidationKey: 3B59C79954BB...
Provided __VIEWSTATEGENERATOR in uint: 3234359391
simulateTemplateSourceDirectory returns: /
simulateGetTypeName returns: _default_aspx
Calculated pageHashCode in uint (ignored): 460985631
/wEywBEAAQAAAP////8BAAAAAAAAAAwCAAAASVN5c3RlbSwgVmVyc...
```