### PR TITLE
Fixing the single quote escaping issue in JSON messages

### DIFF
--- a/ysoserial/Helpers/CommandArgSplitter.cs
+++ b/ysoserial/Helpers/CommandArgSplitter.cs
@@ -24,10 +24,10 @@ namespace ysoserial.Helpers
             if (cmdType == CommandType.JSON)
             {
                 // escape for JSON
-                result[0] = result[0].Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\'");
+                result[0] = result[0].Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\\'");
                 if (hasArgs)
                 {
-                    result[1] = result[1].Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\'");
+                    result[1] = result[1].Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("'", "\\'");
                 }
             }
             else if (cmdType == CommandType.XML)


### PR DESCRIPTION
Fixing the single quote escaping issue in JSON messages. See https://github.com/pwntester/ysoserial.net/pull/135 for the bug report.