### PR TITLE
Reduced the necessary code to achieve gadget generation for MessagePackTypeless

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ ysoserial.net generates deserialization payloads for a variety of .NET formatter
 			                               (uses serialized Claims)
 			
 	(*) ObjectDataProvider
-		Formatters: DataContractSerializer (2) , FastJson , FsPickler , JavaScriptSerializer , Json.Net , MessagePackTypeless , MessagePackTypelessLz4 , SharpSerializerBinary , SharpSerializerXml , Xaml (4) , XmlSerializer (2) , YamlDotNet < 5.0.0
+		Formatters: DataContractSerializer (2) , FastJson , FsPickler , JavaScriptSerializer , Json.Net , MessagePackTypeless >= 2.3.75, MessagePackTypelessLz4 >= 2.3.75 , SharpSerializerBinary , SharpSerializerXml , Xaml (4) , XmlSerializer (2) , YamlDotNet < 5.0.0
 			Labels: Not bridge or derived
 			Extra options:
 			      --var, --variant=VALUE Payload variant number where applicable. 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ ysoserial.net generates deserialization payloads for a variety of .NET formatter
 			                               (uses serialized Claims)
 			
 	(*) ObjectDataProvider
-		Formatters: DataContractSerializer (2) , FastJson , FsPickler , JavaScriptSerializer , Json.Net , SharpSerializerBinary , SharpSerializerXml , Xaml (4) , XmlSerializer (2) , YamlDotNet < 5.0.0
+		Formatters: DataContractSerializer (2) , FastJson , FsPickler , JavaScriptSerializer , Json.Net , MessagePackTypeless , MessagePackTypelessLz4 , SharpSerializerBinary , SharpSerializerXml , Xaml (4) , XmlSerializer (2) , YamlDotNet < 5.0.0
 			Labels: Not bridge or derived
 			Extra options:
 			      --var, --variant=VALUE Payload variant number where applicable. 

--- a/ysoserial/Helpers/GadgetSurrogates/ObjectDataProviderSurrogates.cs
+++ b/ysoserial/Helpers/GadgetSurrogates/ObjectDataProviderSurrogates.cs
@@ -1,0 +1,28 @@
+﻿namespace ysoserial.Helpers.SurrogateClasses
+{
+    /// <summary>
+    /// Surrogate class for bait-and-switch version of ObjectDataProvider.
+    /// </summary>
+    internal sealed class ObjectDataProviderSurrogate
+    {
+        public string MethodName { get; set; }
+        public object ObjectInstance { get; set; }
+    }
+
+    /// <summary>
+    /// Surrogate class for bait-and-switch version of ProcessStartInfo.
+    /// </summary>
+    internal sealed class ProcessStartInfoSurrogate
+    {
+        public string FileName { get; set; }
+        public string Arguments { get; set; }
+    }
+
+    /// <summary>
+    /// Surrogate class for bait-and-switch version of Process.
+    /// </summary>
+    internal sealed class ProcessSurrogate
+    {
+        public ProcessStartInfoSurrogate StartInfo { get; set; }
+    }
+}

--- a/ysoserial/Program.cs
+++ b/ysoserial/Program.cs
@@ -561,7 +561,7 @@ namespace ysoserial
         private static string GetDefaultOutputFormat(string formatter_name)
         {
             string result = "raw";
-            List<String> base64Default = new List<string>() { "BinaryFormatter", "ObjectStateFormatter" }; // LosFormatter is already base64 encoded
+            List<String> base64Default = new List<string>() { "BinaryFormatter", "ObjectStateFormatter", "MessagePackTypeless", "MessagePackTypelessLz4", "SharpSerializerBinary" }; // LosFormatter is already base64 encoded
             var b64match = base64Default.FirstOrDefault(b64formatter => String.Equals(b64formatter, formatter_name, StringComparison.OrdinalIgnoreCase));
             if (b64match != null)
                 result = "base64";

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Generators\WindowsClaimsIdentityGenerator.cs" />
     <Compile Include="Generators\WindowsIdentityGenerator.cs" />
     <Compile Include="Helpers\JsonHelper.cs" />
+    <Compile Include="Helpers\GadgetSurrogates\ObjectDataProviderSurrogates.cs" />
     <Compile Include="Helpers\TestingArena\TestingArenaHome.cs" />
     <Compile Include="Helpers\XmlHelper.cs" />
     <Compile Include="Helpers\YamlDocumentHelper.cs" />


### PR DESCRIPTION
After running through some test code today I found that the approach of using a dynamic assembly to generate surrogate types isn't actually necessary. You can simply write the surrogate classes manually and then reference them, even if they're in the same assembly and it'll still work just fine.

I've made the changes as described above and also added MessagePackTypeless and MessagePackTypelessLz4 to the README. In addition I've added them both to the default Base64 behaviour and also included SharpSerializerBinary as that should also be in the same place.

I went back and forth on the pros and cons of continuing to use a dynamic assembly as I figured it reduces clutter in the codebase, since it's only used for generating this payload, however I figured that there may be other serializers that could use the bait-and-switch approach, too. Open to thoughts on this.