### PR TITLE
support pre-compiled DLL in LocalCodeCompiler helper

### DIFF
--- a/ysoserial/Helpers/LocalCodeCompiler.cs
+++ b/ysoserial/Helpers/LocalCodeCompiler.cs
@@ -15,7 +15,25 @@ namespace ysoserial.Helpers
 
         public static byte[] CompileToAsmBytes(string fileChain)
         {
-            return CompileToAsmBytes(fileChain, "", "");
+            if (fileChain.EndsWith(".dll") && !fileChain.Contains(".cs;"))
+            {
+                return GetAsmBytes(fileChain);
+            }
+            else
+            {
+                return CompileToAsmBytes(fileChain, "", "");
+            }
+        }
+
+        private static byte[] GetAsmBytes(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                Console.Error.WriteLine("Assembly not found!");
+                Environment.Exit(-1);
+            }
+
+            return File.ReadAllBytes(filePath);
         }
 
         public static byte[] CompileToAsmBytes(string fileChain, string compilerLanguage, string compilerOptions)


### PR DESCRIPTION
This just implements changes suggested by James Williams at TrustedSec (don't know his github handle) in https://trustedsec.com/blog/spec-tac-ula-deserialization-deploying-specula-with-net 

Supporting pre-compiled DLL for XamlAssemblyLoadFromFile and its LocalCodeCompiler  helper can help streamline some cases where a payload has several reference assemblies to add. 